### PR TITLE
Feat/notification

### DIFF
--- a/src/main/java/com/gogym/GoGymApplication.java
+++ b/src/main/java/com/gogym/GoGymApplication.java
@@ -3,9 +3,11 @@ package com.gogym;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableScheduling
 public class GoGymApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/gogym/GoGymApplication.java
+++ b/src/main/java/com/gogym/GoGymApplication.java
@@ -2,11 +2,13 @@ package com.gogym;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableAspectJAutoProxy
 @EnableScheduling
 public class GoGymApplication {
 

--- a/src/main/java/com/gogym/notification/controller/NotificationController.java
+++ b/src/main/java/com/gogym/notification/controller/NotificationController.java
@@ -1,14 +1,13 @@
 package com.gogym.notification.controller;
 
-import static com.gogym.common.response.SuccessCode.SUCCESS;
 import static org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE;
 
-import com.gogym.common.response.ApplicationResponse;
 import com.gogym.notification.dto.NotificationDto;
 import com.gogym.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -23,30 +22,33 @@ public class NotificationController {
 
   private final NotificationService notificationService;
 
-  @GetMapping(value = "/subscribe/{memberId}", produces = TEXT_EVENT_STREAM_VALUE)
-  public SseEmitter subscribe(@PathVariable Long memberId) {
+  // TODO : 파라미터로 memberId 를 받는것이 아닌 token 으로 받는것으로 수정 {member-id} 제거
+  @GetMapping(value = "/subscribe/{member-id}", produces = TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter subscribe(@PathVariable("member-id") Long memberId) {
 
     return notificationService.subscribe(memberId);
   }
 
   @GetMapping
-  public ApplicationResponse<Page<NotificationDto>> getAllNotifications(Pageable pageable) {
+  public ResponseEntity<Page<NotificationDto>> getAllNotifications(Pageable pageable) {
 
+    // TODO : 하드코딩 추후 변경
     Long memberId = 1L;
 
     Page<NotificationDto> notifications = notificationService.getAllNotifications(memberId,
         pageable);
 
-    return ApplicationResponse.ok(notifications, SUCCESS);
+    return ResponseEntity.ok(notifications);
   }
 
-  @PutMapping("/{id}/read")
-  public ApplicationResponse<Void> updateNotification(@PathVariable Long id) {
+  @PutMapping("/{notification-id}/read")
+  public ResponseEntity<Void> updateNotification(@PathVariable("notification-id") Long notificationId) {
 
+    // TODO : 하드코딩 추후 변경
     Long memberId = 1L;
 
-    notificationService.updateNotification(id, memberId);
+    notificationService.updateNotification(notificationId, memberId);
 
-    return ApplicationResponse.noData(SUCCESS);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/com/gogym/notification/controller/NotificationController.java
+++ b/src/main/java/com/gogym/notification/controller/NotificationController.java
@@ -1,5 +1,52 @@
 package com.gogym.notification.controller;
 
+import static com.gogym.common.response.SuccessCode.SUCCESS;
+import static org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE;
+
+import com.gogym.common.response.ApplicationResponse;
+import com.gogym.notification.dto.NotificationDto;
+import com.gogym.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
 public class NotificationController {
 
+  private final NotificationService notificationService;
+
+  @GetMapping(value = "/subscribe/{memberId}", produces = TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter subscribe(@PathVariable Long memberId) {
+
+    return notificationService.subscribe(memberId);
+  }
+
+  @GetMapping
+  public ApplicationResponse<Page<NotificationDto>> getAllNotifications(Pageable pageable) {
+
+    Long memberId = 1L;
+
+    Page<NotificationDto> notifications = notificationService.getAllNotifications(memberId,
+        pageable);
+
+    return ApplicationResponse.ok(notifications, SUCCESS);
+  }
+
+  @PutMapping("/{id}/read")
+  public ApplicationResponse<Void> updateNotification(@PathVariable Long id) {
+
+    Long memberId = 1L;
+
+    notificationService.updateNotification(id, memberId);
+
+    return ApplicationResponse.noData(SUCCESS);
+  }
 }

--- a/src/main/java/com/gogym/notification/dto/NotificationDto.java
+++ b/src/main/java/com/gogym/notification/dto/NotificationDto.java
@@ -1,5 +1,25 @@
 package com.gogym.notification.dto;
 
+import com.gogym.notification.entity.Notification;
+import com.gogym.notification.type.NotificationType;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class NotificationDto {
 
+  private NotificationType type;
+
+  private String content;
+
+  private LocalDateTime createdAt;
+
+  public static NotificationDto fromEntity(Notification notification) {
+    return new NotificationDto(notification.getType(), notification.getContent(),
+        notification.getCreatedAt());
+  }
 }

--- a/src/main/java/com/gogym/notification/dto/NotificationDto.java
+++ b/src/main/java/com/gogym/notification/dto/NotificationDto.java
@@ -3,20 +3,14 @@ package com.gogym.notification.dto;
 import com.gogym.notification.entity.Notification;
 import com.gogym.notification.type.NotificationType;
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class NotificationDto {
+public record NotificationDto(
 
-  private NotificationType type;
+  NotificationType type,
+  String content,
+  LocalDateTime createdAt
 
-  private String content;
-
-  private LocalDateTime createdAt;
+  ) {
 
   public static NotificationDto fromEntity(Notification notification) {
     return new NotificationDto(notification.getType(), notification.getContent(),

--- a/src/main/java/com/gogym/notification/entity/Notification.java
+++ b/src/main/java/com/gogym/notification/entity/Notification.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,8 +16,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Table(name = "notifications")
 public class Notification extends BaseEntity {
 
+
+  // TODO : 추후 join column 으로 Member 객체 연결
   private Long memberId;
 
   @Enumerated(EnumType.STRING)
@@ -26,12 +30,12 @@ public class Notification extends BaseEntity {
   @Column(nullable = false)
   private String content;
 
-  @Column(nullable = false)
+  @Column(name = "is_read", nullable = false)
   private Boolean isRead;
 
   public static Notification of(Long memberId, NotificationDto notificationdto) {
 
-    return new Notification(memberId, notificationdto.getType(), notificationdto.getContent(), false);
+    return new Notification(memberId, notificationdto.type(), notificationdto.content(), false);
   }
 
   public void read() {

--- a/src/main/java/com/gogym/notification/entity/Notification.java
+++ b/src/main/java/com/gogym/notification/entity/Notification.java
@@ -1,0 +1,40 @@
+package com.gogym.notification.entity;
+
+import com.gogym.common.entity.BaseEntity;
+import com.gogym.notification.dto.NotificationDto;
+import com.gogym.notification.type.NotificationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class Notification extends BaseEntity {
+
+  private Long memberId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private NotificationType type;
+
+  @Column(nullable = false)
+  private String content;
+
+  @Column(nullable = false)
+  private Boolean isRead;
+
+  public static Notification of(Long memberId, NotificationDto notificationdto) {
+
+    return new Notification(memberId, notificationdto.getType(), notificationdto.getContent(), false);
+  }
+
+  public void read() {
+    this.isRead = true;
+  }
+}

--- a/src/main/java/com/gogym/notification/entity/NotificationEntity.java
+++ b/src/main/java/com/gogym/notification/entity/NotificationEntity.java
@@ -1,5 +1,0 @@
-package com.gogym.notification.entity;
-
-public class NotificationEntity {
-
-}

--- a/src/main/java/com/gogym/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/gogym/notification/repository/NotificationRepository.java
@@ -1,5 +1,14 @@
 package com.gogym.notification.repository;
 
-public interface NotificationRepository{
+import com.gogym.notification.entity.Notification;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
 
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+  Page<Notification> findAllByMemberIdAndIsReadFalse(Long memberId, Pageable pageable);
+
+  Optional<Notification> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/com/gogym/notification/service/NotificationService.java
+++ b/src/main/java/com/gogym/notification/service/NotificationService.java
@@ -1,5 +1,140 @@
 package com.gogym.notification.service;
 
+import static com.gogym.common.response.ErrorCode.ALREADY_READ;
+import static com.gogym.common.response.ErrorCode.REQUEST_NOT_FOUND;
+
+import com.gogym.exception.CustomException;
+import com.gogym.notification.dto.NotificationDto;
+import com.gogym.notification.entity.Notification;
+import com.gogym.notification.repository.NotificationRepository;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@RequiredArgsConstructor
 public class NotificationService {
 
+  private final NotificationRepository notificationRepository;
+
+  private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+  public SseEmitter subscribe(Long memberId) {
+
+    // TODO : Member 객체 검증 로직
+
+    SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+    emitters.put(memberId, emitter);
+
+    // 클라이언트 연결 종료, 만료, 에러 처리
+    emitter.onCompletion(() -> removeEmitter(memberId));
+    emitter.onTimeout(() -> removeEmitter(memberId));
+    emitter.onError((e) -> removeEmitter(memberId));
+
+    sendDummyData(memberId, emitter);
+
+    return emitter;
+  }
+
+  private void removeEmitter(Long memberId) {
+    emitters.remove(memberId);
+  }
+
+  public void sendDummyData(Long memberId, SseEmitter emitter) {
+
+    // 연결이 되었으면 더미(뻥) 데이터 전송(클라이언트에서 확인용으로 사용하면 될 것 같습니다.)
+    if (emitter != null) {
+      try {
+        emitter.send(SseEmitter.event()
+            .name("dummy")
+            .data("Well Connected! Waiting for notifications."));
+      } catch (IOException e) {
+        removeEmitter(memberId);
+      }
+    }
+  }
+
+  @Scheduled(fixedRate = 30000)
+  public void sendHeartbeat() {
+    emitters.keySet().forEach(this::sendHeartbeat);
+  }
+
+  /*
+  클라이언트와 연결이 원활이 되었는지 확인하는 메서드입니다.
+  클라이언트 측에서 해당 메세지를 30초마다 한번씩 받지 못하면 재연결 하는 로직을 구현해야 할 것 같습니다.
+   */
+  public void sendHeartbeat(Long memberId) {
+
+    SseEmitter emitter = emitters.get(memberId);
+    if (emitter != null) {
+      try {
+        emitter.send(SseEmitter.event()
+            .name("heartbeat")
+            .data("connecting..."));
+      } catch (IOException e) {
+        removeEmitter(memberId);
+      }
+    }
+  }
+
+  // 다른 서비스 로직에서 트리거가 되는 메서드에 사용되면 될 것 같습니다.
+  @Transactional
+  public void createNotification(Long memberId, NotificationDto notificationDto) {
+
+    // TODO : Member 객체 검증 로직
+
+    Notification notification = Notification.of(memberId, notificationDto);
+
+    // 알림받을 회원이 구독하지 않은상태(로그인 하지 않은 상태) 이더라도 알림은 저장이 됩니다.
+    notificationRepository.save(notification);
+
+    sendNotification(memberId, notification);
+  }
+
+  public void sendNotification(Long memberId, Notification notification) {
+
+    // notification 테이블에 저장 후 사용자에게 전송
+    SseEmitter emitter = emitters.get(memberId);
+    if (emitter != null) {
+      try {
+        NotificationDto notificationDto = NotificationDto.fromEntity(notification);
+        emitter.send(SseEmitter.event()
+            .name("notification")
+            .data(notificationDto));
+      } catch (IOException e) {
+        removeEmitter(memberId);
+      }
+    }
+  }
+
+  @Transactional(readOnly = true)
+  public Page<NotificationDto> getAllNotifications(Long memberId, Pageable pageable) {
+
+    // TODO : Member 객체 검증 로직
+
+    // 읽지않은 알림목록만 받아옵니다.
+    Page<Notification> notificationPage = notificationRepository.findAllByMemberIdAndIsReadFalse(
+        memberId, pageable);
+
+    return notificationPage.map(NotificationDto::fromEntity);
+  }
+
+  @Transactional
+  public void updateNotification(Long id, Long memberId) {
+
+    Notification notification = notificationRepository.findByIdAndMemberId(id, memberId)
+        .orElseThrow(() -> new CustomException(REQUEST_NOT_FOUND));
+
+    if (notification.getIsRead()) {
+      throw new CustomException(ALREADY_READ, "이미 읽은 알림입니다.");
+    }
+    notification.read();
+  }
 }

--- a/src/main/java/com/gogym/notification/type/NotificationType.java
+++ b/src/main/java/com/gogym/notification/type/NotificationType.java
@@ -1,0 +1,10 @@
+package com.gogym.notification.type;
+
+public enum NotificationType {
+
+  // 타인이 내 게시글에 찜을 한 경우
+  ADD_WISHLIST_MY_POST,
+
+  // 내 회원상태가 변경된 경우 (경고 1회, 경고2회 등)
+  CHANGE_MEMBER_STATUS
+}

--- a/src/test/java/com/gogym/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/gogym/notification/service/NotificationServiceTest.java
@@ -145,7 +145,7 @@ class NotificationServiceTest {
   }
 
   @Test
-  @DisplayName("회원의 알림이 없으면 예외가 발생한다,")
+  @DisplayName("회원의 알림이 없으면 예외가 발생한다.")
   void updateNotification_shouldThrowExceptionWhenNotificationNotFound() {
     // given
     Long notificationId = 1L;

--- a/src/test/java/com/gogym/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/gogym/notification/service/NotificationServiceTest.java
@@ -1,0 +1,174 @@
+package com.gogym.notification.service;
+
+import static com.gogym.common.response.ErrorCode.ALREADY_READ;
+import static com.gogym.common.response.ErrorCode.REQUEST_NOT_FOUND;
+import static com.gogym.notification.type.NotificationType.ADD_WISHLIST_MY_POST;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.gogym.exception.CustomException;
+import com.gogym.notification.dto.NotificationDto;
+import com.gogym.notification.entity.Notification;
+import com.gogym.notification.repository.NotificationRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+  @Mock
+  private NotificationRepository notificationRepository;
+
+  @Mock
+  private SseEmitter sseEmitter;
+
+  @InjectMocks
+  private NotificationService notificationService;
+
+  private Notification notification;
+  private Notification readNotification;
+  private NotificationDto notificationDto;
+  private final Pageable pageable = Pageable.ofSize(10);
+  private final Long memberId = 1L;
+
+  @BeforeEach
+  void setUp() {
+
+    notificationDto = new NotificationDto(ADD_WISHLIST_MY_POST, "test message", null);
+    notification = Notification.of(memberId, notificationDto);
+    readNotification = new Notification(memberId, ADD_WISHLIST_MY_POST, "test message", true);
+  }
+
+  private Map<Long, SseEmitter> emitters() {
+    return (Map<Long, SseEmitter>) ReflectionTestUtils.getField(notificationService, "emitters");
+  }
+
+  @Test
+  @DisplayName("구독을 신청한 회원은 Map 에 등록되어 관리된다.")
+  void subscribe_shouldAddEmitterToMap() {
+    // given
+    // when
+    sseEmitter = notificationService.subscribe(memberId);
+    // then
+    assertNotNull(sseEmitter);
+    Map<Long, SseEmitter> emitters = emitters();
+    assertTrue(emitters.containsKey(memberId));
+  }
+
+  @Test
+  @DisplayName("알림 생성 시 DB 에 저장된다.")
+  void createNotification_shouldSaveNotification() {
+    // given
+    // when
+    notificationService.createNotification(memberId, notificationDto);
+    // then
+    verify(notificationRepository).save(any());
+  }
+
+  @Test
+  @DisplayName("저장된 알림이 있고 읽지 않은 경우 알림이 조회된다.")
+  void getAllNotifications_shouldReturnUnReadNotifications() {
+    // given
+    Page<Notification> notificationPage = new PageImpl<>(List.of(notification));
+    when(notificationRepository.findAllByMemberIdAndIsReadFalse(memberId, pageable)).thenReturn(
+        notificationPage);
+    // when
+    Page<NotificationDto> notifications = notificationService.getAllNotifications(memberId,
+        pageable);
+    // then
+    assertNotNull(notifications);
+    assertFalse(notifications.isEmpty());
+    assertEquals(1, notifications.getTotalElements());
+  }
+
+  @Test
+  @DisplayName("저장된 알림이 없는 경우 빈 배열을 반환한다.")
+  void getAllNotifications_shouldReturnEmptyNotifications() {
+    // given
+    Page<Notification> notificationPage = Page.empty();
+
+    when(notificationRepository.findAllByMemberIdAndIsReadFalse(memberId, pageable)).thenReturn(
+        notificationPage);
+    // when
+    Page<NotificationDto> notifications = notificationService.getAllNotifications(memberId,
+        pageable);
+    // then
+    assertNotNull(notifications);
+    assertTrue(notifications.isEmpty());
+  }
+
+  @Test
+  @DisplayName("저장된 알림이 있고, 읽은 상태면 빈 배열을 반환한다.")
+  void getAllNotifications_shouldReturnEmptyWhenAllNotificationsRead() {
+    // given
+    Page<Notification> notificationPage = new PageImpl<>(List.of(readNotification));
+    when(notificationRepository.findAllByMemberIdAndIsReadFalse(memberId, pageable)).thenReturn(
+        notificationPage);
+    // when
+    Page<NotificationDto> notifications = notificationService.getAllNotifications(memberId,
+        pageable);
+    // then
+    assertNotNull(notifications);
+    assertFalse(notifications.isEmpty());
+  }
+
+  @Test
+  @DisplayName("알림을 읽음 상태로 변경 요청이 오면 읽음 상태로 변경한다.")
+  void updateNotification_shouldMarkAsRead() {
+    // given
+    Long notificationId = 1L;
+    when(notificationRepository.findByIdAndMemberId(notificationId, memberId)).thenReturn(
+        Optional.of(notification));
+    // when
+    notificationService.updateNotification(notificationId, memberId);
+    // then
+    assertTrue(notification.getIsRead());
+  }
+
+  @Test
+  @DisplayName("회원의 알림이 없으면 예외가 발생한다,")
+  void updateNotification_shouldThrowExceptionWhenNotificationNotFound() {
+    // given
+    Long notificationId = 1L;
+    when(notificationRepository.findByIdAndMemberId(notificationId, memberId)).thenReturn(
+        Optional.empty());
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> notificationService.updateNotification(notificationId, memberId));
+    // then
+    assertEquals(REQUEST_NOT_FOUND, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("이미 읽은 상태의 알림의 읽음요청을 보내면 예외가 발생한다.")
+  void updateNotification_shouldThrowExceptionWhenNotificationAlreadyRead() {
+    // given
+    Long notificationId = 1L;
+    when(notificationRepository.findByIdAndMemberId(notificationId, memberId)).thenReturn(
+        Optional.of(readNotification));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> notificationService.updateNotification(notificationId, memberId));
+    // then
+    assertEquals(ALREADY_READ, e.getErrorCode());
+  }
+}


### PR DESCRIPTION
## ⚡️ Issue 번호
<!-- 작업한 내용에 해당하는 Issue 번호를 꼭! 기록해주세요 !
키워드: close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved
예시: close #10 !-->
알림관련 https://github.com/ProjectGoGym/BackEnd/issues/5
## 🛠️ 작업 내용 (What)
- 알림 관련 기능 구현

## 📌 작업 이유 (Why)
- 회원이 올린 게시글에 찜이 추가 된경우 알림이 발송됩니다.
- 회원의 상태(경고 누적 등) 가 변경 될 경우 알림이 발송됩니다.
- 알림이 실시간으로 소통되기 위해 SSE 를 사용하고, 이를 통해 로그인된 경우 SSE 를 연결시킵니다.

## ✨ 변경 사항 (Changes)
- SSE 관련
  - 클라이언트와 실시간 소통을 위해 SSE 구독 요청을 받습니다.
  - 구독 요청이 완료되면 더미 데이터를 보내 성공적인 연결 확인을 합니다.
  - 특수한 상황에서 연결이 끊어질 수 있어 지속적으로 연결중이라는 메세지를 전송합니다.
  - 로그아웃 된 상황, 시간 종료, 창 닫기, 에러 등 여러 상황에서 구독을 끊어 효율적인 관리를 합니다
- 알림 생성
  - 알림이 생성되면 알림 정보를 DB 에 저장하고 회원이 SSE 에 구독이 되어있는 경우에 알림을 전송합니다.
  - 회원이 구독되어있지 않은상태이더라도 DB 에 알림이 저장됩니다.
- 알림 조회
  - 회원이 읽지 않은 알림은 페이징처리 되어 확인이 가능합니다.
  - 만약 읽은 상태의 알림이라면, 조회 요청 시 조회가 되지 않습니다.
  - 읽지 않은 알림이 없으면 빈 배열이 반환됩니다.
- 알림 확인
  - 회원의 알림을 읽은 상태로 변경되면 isRead 필드가 true 로 변경되어 읽은상태로 변경됩니다.
  - 회원의 ID 나 요청한 알림 ID 가 없는 경우 예외가 발생합니다.

## ✅ 테스트 (Tests)
- [ ]  구독을 신청한 회원은 Map 에 등록되어 관리된다.
- [ ] 알림 생성 시 DB 에 저장된다.
- [ ] 저장된 알림이 있고 읽지 않은 경우 알림이 조회된다.
- [ ] 저장된 알림이 없는 경우 빈 배열을 반환한다.
- [ ] 저장된 알림이 있고, 읽은 상태면 빈 배열을 반환한다.
- [ ] 알림을 읽음 상태로 변경 요청이 오면 읽음 상태로 변경한다.
- [ ] 회원의 알림이 없으면 예외가 발생한다,
- [ ] 이미 읽은 상태의 알림의 읽음요청을 보내면 예외가 발생한다.

## 💬 리뷰 포인트 (Review Points)
- Controller 와 Service 에서 회원의 정보를 검증하는 부분(TODO) 은 추후 회원관련 설정이 완료되면 변경 예정입니다.
- 회원관련 로직이 완료되면 각 상황에 대한 예외처리(회원이 없다, 권한이 없다 등) 추가 예정입니다.
- 테스트코드 작성 시 SSE 관련은 Mock 데이터로 아무리 해도 확인이 어려워 추 후 클라이언트와 연결 테스트때 시도 해봐야할 부분인것 같습니다.
- Type 관련은 추후에 추가하거나 하면 좋을것 같습니다 혹시라도 추가하면 좋은 상태가 있다면 논의해보면 좋을 것 같습니다.

대신 구독 연결 테스트는 로컬에서 확인했습니다.
<img width="1840" alt="스크린샷 2024-11-27 오후 12 58 18" src="https://github.com/user-attachments/assets/86966bab-7d77-4d6e-8340-e918dd1d7f06">
<img width="986" alt="스크린샷 2024-11-27 오후 12 59 16" src="https://github.com/user-attachments/assets/e7e6d51c-d6f0-4909-95d3-0074bc9b471a">
