### PR TITLE
✨feat : 알림 관련 로직

### DIFF
--- a/src/main/java/com/gogym/GoGymApplication.java
+++ b/src/main/java/com/gogym/GoGymApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @SpringBootApplication
 @EnableAspectJAutoProxy
+@EnableScheduling
 public class GoGymApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/gogym/aop/LoggingAspect.java
+++ b/src/main/java/com/gogym/aop/LoggingAspect.java
@@ -15,7 +15,7 @@ public class LoggingAspect {
   @Pointcut("execution(* com.gogym..controller..*(..))")
   public void apiLayer() {}
 
-  @Pointcut("execution(* com.gogym..service..*(..))")
+  @Pointcut("execution(* com.gogym..service..*(..)) && !execution(* com.gogym..schedule..*(..))")
   public void serviceLayer() {}
 
   @Around("apiLayer()")

--- a/src/main/java/com/gogym/notification/controller/NotificationController.java
+++ b/src/main/java/com/gogym/notification/controller/NotificationController.java
@@ -1,5 +1,54 @@
 package com.gogym.notification.controller;
 
+import static org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE;
+
+import com.gogym.notification.dto.NotificationDto;
+import com.gogym.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
 public class NotificationController {
 
+  private final NotificationService notificationService;
+
+  // TODO : 파라미터로 memberId 를 받는것이 아닌 token 으로 받는것으로 수정 {member-id} 제거
+  @GetMapping(value = "/subscribe/{member-id}", produces = TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter subscribe(@PathVariable("member-id") Long memberId) {
+
+    return notificationService.subscribe(memberId);
+  }
+
+  @GetMapping
+  public ResponseEntity<Page<NotificationDto>> getAllNotifications(Pageable pageable) {
+
+    // TODO : 하드코딩 추후 변경
+    Long memberId = 1L;
+
+    Page<NotificationDto> notifications = notificationService.getAllNotifications(memberId,
+        pageable);
+
+    return ResponseEntity.ok(notifications);
+  }
+
+  @PutMapping("/{notification-id}/read")
+  public ResponseEntity<Void> updateNotification(@PathVariable("notification-id") Long notificationId) {
+
+    // TODO : 하드코딩 추후 변경
+    Long memberId = 1L;
+
+    notificationService.updateNotification(notificationId, memberId);
+
+    return ResponseEntity.ok().build();
+  }
 }

--- a/src/main/java/com/gogym/notification/dto/NotificationDto.java
+++ b/src/main/java/com/gogym/notification/dto/NotificationDto.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 
 public record NotificationDto(
 
+    Long notificationId,
     NotificationType type,
     String content,
     LocalDateTime createdAt
@@ -13,7 +14,7 @@ public record NotificationDto(
 ) {
 
   public static NotificationDto fromEntity(Notification notification) {
-    return new NotificationDto(notification.getType(), notification.getContent(),
+    return new NotificationDto(notification.getId(), notification.getType(), notification.getContent(),
         notification.getCreatedAt());
   }
 }

--- a/src/main/java/com/gogym/notification/dto/NotificationDto.java
+++ b/src/main/java/com/gogym/notification/dto/NotificationDto.java
@@ -1,5 +1,19 @@
 package com.gogym.notification.dto;
 
-public class NotificationDto {
+import com.gogym.notification.entity.Notification;
+import com.gogym.notification.type.NotificationType;
+import java.time.LocalDateTime;
 
+public record NotificationDto(
+
+    NotificationType type,
+    String content,
+    LocalDateTime createdAt
+
+) {
+
+  public static NotificationDto fromEntity(Notification notification) {
+    return new NotificationDto(notification.getType(), notification.getContent(),
+        notification.getCreatedAt());
+  }
 }

--- a/src/main/java/com/gogym/notification/entity/Notification.java
+++ b/src/main/java/com/gogym/notification/entity/Notification.java
@@ -1,0 +1,47 @@
+package com.gogym.notification.entity;
+
+import com.gogym.common.entity.BaseEntity;
+import com.gogym.member.entity.Member;
+import com.gogym.notification.dto.NotificationDto;
+import com.gogym.notification.type.NotificationType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Table(name = "notifications")
+public class Notification extends BaseEntity {
+
+  @JoinColumn(name = "member_id", nullable = false)
+  @ManyToOne
+  private Member member;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private NotificationType type;
+
+  @Column(nullable = false)
+  private String content;
+
+  @Column(name = "is_read", nullable = false)
+  private Boolean isRead;
+
+  public static Notification of(Member member, NotificationDto notificationdto) {
+
+    return new Notification(member, notificationdto.type(), notificationdto.content(), false);
+  }
+
+  public void read() {
+    this.isRead = true;
+  }
+}

--- a/src/main/java/com/gogym/notification/entity/Notification.java
+++ b/src/main/java/com/gogym/notification/entity/Notification.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -23,7 +24,7 @@ import lombok.NoArgsConstructor;
 public class Notification extends BaseEntity {
 
   @JoinColumn(name = "member_id", nullable = false)
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   private Member member;
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/gogym/notification/entity/NotificationEntity.java
+++ b/src/main/java/com/gogym/notification/entity/NotificationEntity.java
@@ -1,5 +1,0 @@
-package com.gogym.notification.entity;
-
-public class NotificationEntity {
-
-}

--- a/src/main/java/com/gogym/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/gogym/notification/repository/NotificationRepository.java
@@ -1,5 +1,14 @@
 package com.gogym.notification.repository;
 
-public interface NotificationRepository{
+import com.gogym.notification.entity.Notification;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
 
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+  Page<Notification> findAllByMemberIdAndIsReadFalse(Long memberId, Pageable pageable);
+
+  Optional<Notification> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/com/gogym/notification/schedule/NotificationSchedule.java
+++ b/src/main/java/com/gogym/notification/schedule/NotificationSchedule.java
@@ -1,0 +1,18 @@
+package com.gogym.notification.schedule;
+
+import com.gogym.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationSchedule {
+
+  private final NotificationService notificationService;
+
+  @Scheduled(fixedRate = 30000)
+  public void sendHeartbeatScheduled() {
+    notificationService.getEmitters().keySet().forEach(notificationService::sendHeartbeat);
+  }
+}

--- a/src/main/java/com/gogym/notification/service/NotificationService.java
+++ b/src/main/java/com/gogym/notification/service/NotificationService.java
@@ -1,5 +1,160 @@
 package com.gogym.notification.service;
 
+import static com.gogym.exception.ErrorCode.ALREADY_READ;
+import static com.gogym.exception.ErrorCode.MEMBER_NOT_FOUND;
+import static com.gogym.exception.ErrorCode.NOTIFICATION_NOT_FOUND;
+
+import com.gogym.exception.CustomException;
+import com.gogym.member.entity.Member;
+import com.gogym.member.repository.MemberRepository;
+import com.gogym.notification.dto.NotificationDto;
+import com.gogym.notification.entity.Notification;
+import com.gogym.notification.repository.NotificationRepository;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
 public class NotificationService {
 
+  private final NotificationRepository notificationRepository;
+
+  private final MemberRepository memberRepository;
+
+  @Getter
+  private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+  public SseEmitter subscribe(Long memberId) {
+
+    findByMemberFromMemberRepository(memberId);
+
+    SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+    emitters.put(memberId, emitter);
+
+    // 클라이언트 연결 종료, 만료, 에러 처리
+    emitter.onCompletion(() -> removeEmitter(memberId));
+    emitter.onTimeout(() -> removeEmitter(memberId));
+    emitter.onError((e) -> removeEmitter(memberId));
+
+    sendDummyData(memberId, emitter);
+
+    return emitter;
+  }
+
+  private void removeEmitter(Long memberId) {
+    emitters.remove(memberId);
+  }
+
+  public void sendDummyData(Long memberId, SseEmitter emitter) {
+
+    // 연결이 되었으면 더미(뻥) 데이터 전송(클라이언트에서 확인용으로 사용하면 될 것 같습니다.)
+    if (emitter != null) {
+      try {
+        emitter.send(SseEmitter.event()
+            .name("dummy")
+            .data("Well Connected! Waiting for notifications."));
+      } catch (IOException e) {
+        log.error("▶ 더미 데이터 전송 실패 : memberId = {}, 오류 : {}", memberId, e.getMessage());
+        removeEmitter(memberId);
+      }
+    }
+  }
+
+  /*
+  클라이언트와 연결이 원활이 되었는지 확인하는 메서드입니다.
+  클라이언트 측에서 해당 메세지를 30초마다 한번씩 받지 못하면 재연결 하는 로직을 구현해야 할 것 같습니다.
+   */
+  public void sendHeartbeat(Long memberId) {
+
+    SseEmitter emitter = emitters.get(memberId);
+    if (emitter != null) {
+      try {
+        emitter.send(SseEmitter.event()
+            .name("heartbeat")
+            .data("connecting..."));
+      } catch (IOException e) {
+        log.error("▶ 하트비트 메세지 전송 실패 : memberId = {}, 오류 : {}", memberId, e.getMessage());
+        removeEmitter(memberId);
+      }
+    }
+  }
+
+  @Transactional
+  // 다른 서비스 로직에서 트리거가 되는 메서드에 사용되면 될 것 같습니다.
+  public void createNotification(Long memberId, NotificationDto notificationDto) {
+
+    Member member = findByMemberFromMemberRepository(memberId);
+
+    try {
+      Notification notification = Notification.of(member, notificationDto);
+
+      // 알림받을 회원이 구독하지 않은상태(로그인 하지 않은 상태) 이더라도 알림은 저장이 됩니다.
+      notificationRepository.save(notification);
+
+      sendNotification(memberId, notification);
+
+    } catch (Exception e) {
+      log.error("▶ 알림 생성 중 오류 발생 : memberId = {}, notificationDto = {}, 오류 : {}", memberId,
+          notificationDto, e.getMessage());
+    }
+  }
+
+  public void sendNotification(Long memberId, Notification notification) {
+
+    // notification 테이블에 저장 후 사용자에게 전송
+    SseEmitter emitter = emitters.get(memberId);
+    if (emitter != null) {
+      try {
+        NotificationDto notificationDto = NotificationDto.fromEntity(notification);
+        emitter.send(SseEmitter.event()
+            .name("notification")
+            .data(notificationDto));
+      } catch (IOException e) {
+        log.error("▶ 알림 전송 중 오류 발생 : memberId = {}, 오류 : {}", memberId, e.getMessage());
+        removeEmitter(memberId);
+      }
+    }
+  }
+
+  public Page<NotificationDto> getAllNotifications(Long memberId, Pageable pageable) {
+
+    findByMemberFromMemberRepository(memberId);
+
+    // 읽지않은 알림목록만 받아옵니다.
+    Page<Notification> notificationPage = notificationRepository.findAllByMemberIdAndIsReadFalse(
+        memberId, pageable);
+
+    return notificationPage.map(NotificationDto::fromEntity);
+  }
+
+  @Transactional
+  public void updateNotification(Long notificationId, Long memberId) {
+
+    Notification notification = notificationRepository.findByIdAndMemberId(notificationId, memberId)
+        .orElseThrow(() -> new CustomException(NOTIFICATION_NOT_FOUND));
+
+    if (notification.getIsRead()) {
+      log.error("▶ 읽은 상태의 알림 읽기 시도 : memberId = {}, notificationId = {}", memberId, notificationId);
+      throw new CustomException(ALREADY_READ);
+    }
+    notification.read();
+  }
+
+  // 각 메서드 내에서 회원 객체를 확인하는 로직
+  private Member findByMemberFromMemberRepository(Long memberId) {
+
+    return memberRepository.findById(memberId)
+        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+  }
 }

--- a/src/main/java/com/gogym/notification/service/NotificationService.java
+++ b/src/main/java/com/gogym/notification/service/NotificationService.java
@@ -65,7 +65,6 @@ public class NotificationService {
             .name("dummy")
             .data("Well Connected! Waiting for notifications."));
       } catch (IOException e) {
-        log.error("▶ 더미 데이터 전송 실패 : memberId = {}, 오류 : {}", memberId, e.getMessage());
         removeEmitter(memberId);
       }
     }
@@ -84,7 +83,6 @@ public class NotificationService {
             .name("heartbeat")
             .data("connecting..."));
       } catch (IOException e) {
-        log.error("▶ 하트비트 메세지 전송 실패 : memberId = {}, 오류 : {}", memberId, e.getMessage());
         removeEmitter(memberId);
       }
     }
@@ -96,18 +94,12 @@ public class NotificationService {
 
     Member member = findByMemberFromMemberRepository(memberId);
 
-    try {
-      Notification notification = Notification.of(member, notificationDto);
+    Notification notification = Notification.of(member, notificationDto);
 
-      // 알림받을 회원이 구독하지 않은상태(로그인 하지 않은 상태) 이더라도 알림은 저장이 됩니다.
-      notificationRepository.save(notification);
+    // 알림받을 회원이 구독하지 않은상태(로그인 하지 않은 상태) 이더라도 알림은 저장이 됩니다.
+    notificationRepository.save(notification);
 
-      sendNotification(memberId, notification);
-
-    } catch (Exception e) {
-      log.error("▶ 알림 생성 중 오류 발생 : memberId = {}, notificationDto = {}, 오류 : {}", memberId,
-          notificationDto, e.getMessage());
-    }
+    sendNotification(memberId, notification);
   }
 
   public void sendNotification(Long memberId, Notification notification) {
@@ -121,7 +113,6 @@ public class NotificationService {
             .name("notification")
             .data(notificationDto));
       } catch (IOException e) {
-        log.error("▶ 알림 전송 중 오류 발생 : memberId = {}, 오류 : {}", memberId, e.getMessage());
         removeEmitter(memberId);
       }
     }
@@ -145,7 +136,6 @@ public class NotificationService {
         .orElseThrow(() -> new CustomException(NOTIFICATION_NOT_FOUND));
 
     if (notification.getIsRead()) {
-      log.error("▶ 읽은 상태의 알림 읽기 시도 : memberId = {}, notificationId = {}", memberId, notificationId);
       throw new CustomException(ALREADY_READ);
     }
     notification.read();

--- a/src/main/java/com/gogym/notification/type/NotificationType.java
+++ b/src/main/java/com/gogym/notification/type/NotificationType.java
@@ -1,0 +1,10 @@
+package com.gogym.notification.type;
+
+public enum NotificationType {
+
+  // 타인이 내 게시글에 찜을 한 경우
+  ADD_WISHLIST_MY_POST,
+
+  // 내 회원상태가 변경된 경우 (경고 1회, 경고2회 등)
+  CHANGE_MEMBER_STATUS
+}

--- a/src/test/java/com/gogym/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/gogym/notification/service/NotificationServiceTest.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -69,8 +68,7 @@ class NotificationServiceTest {
   }
 
   @Test
-  @DisplayName("구독을 신청한 회원은 Map 에 등록되어 관리된다.")
-  void subscribe_shouldAddEmitterToMap() {
+  void 구독을_신청한_회원은_Map_에_등록되어_관리된다() {
     // given
     when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
     // when
@@ -82,8 +80,7 @@ class NotificationServiceTest {
   }
 
   @Test
-  @DisplayName("알림 생성 시 DB 에 저장된다.")
-  void createNotification_shouldSaveNotification() {
+  void 알림_생성_시_DB_에_저장된다() {
     // given
     when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
     // when
@@ -93,8 +90,7 @@ class NotificationServiceTest {
   }
 
   @Test
-  @DisplayName("저장된 알림이 있고 읽지 않은 경우 알림이 조회된다.")
-  void getAllNotifications_shouldReturnUnReadNotifications() {
+  void 저장된_알림이_있고_읽지_않은_경우_알림이_조회된다() {
     // given
     when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
     Page<Notification> notificationPage = new PageImpl<>(List.of(notification));
@@ -110,8 +106,7 @@ class NotificationServiceTest {
   }
 
   @Test
-  @DisplayName("저장된 알림이 없는 경우 빈 배열을 반환한다.")
-  void getAllNotifications_shouldReturnEmptyNotifications() {
+  void 저장된_알림이_없는_경우_빈_배열을_반환한다() {
     // given
     when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
     Page<Notification> notificationPage = Page.empty();
@@ -127,8 +122,7 @@ class NotificationServiceTest {
   }
 
   @Test
-  @DisplayName("저장된 알림이 있고, 읽은 상태면 빈 배열을 반환한다.")
-  void getAllNotifications_shouldReturnEmptyWhenAllNotificationsRead() {
+  void 저장된_알림이_있고_읽은_상태면_빈_배열을_반환한다() {
     // given
     when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
     Page<Notification> notificationPage = new PageImpl<>(List.of(readNotification));
@@ -143,8 +137,7 @@ class NotificationServiceTest {
   }
 
   @Test
-  @DisplayName("알림을 읽음 상태로 변경 요청이 오면 읽음 상태로 변경한다.")
-  void updateNotification_shouldMarkAsRead() {
+  void 알림을_읽음_상태로_변경_요청이_오면_읽음_상태로_변경한다() {
     // given
     Long notificationId = 1L;
     when(notificationRepository.findByIdAndMemberId(notificationId, member.getId())).thenReturn(
@@ -156,8 +149,7 @@ class NotificationServiceTest {
   }
 
   @Test
-  @DisplayName("회원의 알림이 없으면 예외가 발생한다.")
-  void updateNotification_shouldThrowExceptionWhenNotificationNotFound() {
+  void 회원의_알림이_없으면_예외가_발생한다() {
     // given
     Long notificationId = 1L;
     when(notificationRepository.findByIdAndMemberId(notificationId, member.getId())).thenReturn(
@@ -170,8 +162,7 @@ class NotificationServiceTest {
   }
 
   @Test
-  @DisplayName("이미 읽은 상태의 알림의 읽음요청을 보내면 예외가 발생한다.")
-  void updateNotification_shouldThrowExceptionWhenNotificationAlreadyRead() {
+  void 이미_읽은_상태의_알림의_읽음요청을_보내면_예외가_발생한다() {
     // given
     Long notificationId = 1L;
     when(notificationRepository.findByIdAndMemberId(notificationId, member.getId())).thenReturn(

--- a/src/test/java/com/gogym/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/gogym/notification/service/NotificationServiceTest.java
@@ -1,0 +1,185 @@
+package com.gogym.notification.service;
+
+import static com.gogym.exception.ErrorCode.ALREADY_READ;
+import static com.gogym.exception.ErrorCode.NOTIFICATION_NOT_FOUND;
+import static com.gogym.notification.type.NotificationType.ADD_WISHLIST_MY_POST;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.gogym.exception.CustomException;
+import com.gogym.member.entity.Member;
+import com.gogym.member.repository.MemberRepository;
+import com.gogym.notification.dto.NotificationDto;
+import com.gogym.notification.entity.Notification;
+import com.gogym.notification.repository.NotificationRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+  @Mock
+  private NotificationRepository notificationRepository;
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @Mock
+  private SseEmitter sseEmitter;
+
+  @InjectMocks
+  private NotificationService notificationService;
+
+  private Notification notification;
+  private Notification readNotification;
+  private NotificationDto notificationDto;
+  private Member member;
+  private final Pageable pageable = Pageable.ofSize(10);
+
+  @BeforeEach
+  void setUp() {
+
+    member = Member.builder().id(1L).build();
+    notificationDto = new NotificationDto(ADD_WISHLIST_MY_POST, "test message", null);
+    notification = Notification.of(member, notificationDto);
+    readNotification = new Notification(member, ADD_WISHLIST_MY_POST, "test message", true);
+  }
+
+  private Map<Long, SseEmitter> emitters() {
+    return (Map<Long, SseEmitter>) ReflectionTestUtils.getField(notificationService, "emitters");
+  }
+
+  @Test
+  @DisplayName("구독을 신청한 회원은 Map 에 등록되어 관리된다.")
+  void subscribe_shouldAddEmitterToMap() {
+    // given
+    when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+    // when
+    sseEmitter = notificationService.subscribe(member.getId());
+    // then
+    assertNotNull(sseEmitter);
+    Map<Long, SseEmitter> emitters = emitters();
+    assertTrue(emitters.containsKey(member.getId()));
+  }
+
+  @Test
+  @DisplayName("알림 생성 시 DB 에 저장된다.")
+  void createNotification_shouldSaveNotification() {
+    // given
+    when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+    // when
+    notificationService.createNotification(member.getId(), notificationDto);
+    // then
+    verify(notificationRepository).save(any());
+  }
+
+  @Test
+  @DisplayName("저장된 알림이 있고 읽지 않은 경우 알림이 조회된다.")
+  void getAllNotifications_shouldReturnUnReadNotifications() {
+    // given
+    when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+    Page<Notification> notificationPage = new PageImpl<>(List.of(notification));
+    when(notificationRepository.findAllByMemberIdAndIsReadFalse(member.getId(), pageable)).thenReturn(
+        notificationPage);
+    // when
+    Page<NotificationDto> notifications = notificationService.getAllNotifications(member.getId(),
+        pageable);
+    // then
+    assertNotNull(notifications);
+    assertFalse(notifications.isEmpty());
+    assertEquals(1, notifications.getTotalElements());
+  }
+
+  @Test
+  @DisplayName("저장된 알림이 없는 경우 빈 배열을 반환한다.")
+  void getAllNotifications_shouldReturnEmptyNotifications() {
+    // given
+    when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+    Page<Notification> notificationPage = Page.empty();
+
+    when(notificationRepository.findAllByMemberIdAndIsReadFalse(member.getId(), pageable)).thenReturn(
+        notificationPage);
+    // when
+    Page<NotificationDto> notifications = notificationService.getAllNotifications(member.getId(),
+        pageable);
+    // then
+    assertNotNull(notifications);
+    assertTrue(notifications.isEmpty());
+  }
+
+  @Test
+  @DisplayName("저장된 알림이 있고, 읽은 상태면 빈 배열을 반환한다.")
+  void getAllNotifications_shouldReturnEmptyWhenAllNotificationsRead() {
+    // given
+    when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
+    Page<Notification> notificationPage = new PageImpl<>(List.of(readNotification));
+    when(notificationRepository.findAllByMemberIdAndIsReadFalse(member.getId(), pageable)).thenReturn(
+        notificationPage);
+    // when
+    Page<NotificationDto> notifications = notificationService.getAllNotifications(member.getId(),
+        pageable);
+    // then
+    assertNotNull(notifications);
+    assertFalse(notifications.isEmpty());
+  }
+
+  @Test
+  @DisplayName("알림을 읽음 상태로 변경 요청이 오면 읽음 상태로 변경한다.")
+  void updateNotification_shouldMarkAsRead() {
+    // given
+    Long notificationId = 1L;
+    when(notificationRepository.findByIdAndMemberId(notificationId, member.getId())).thenReturn(
+        Optional.of(notification));
+    // when
+    notificationService.updateNotification(notificationId, member.getId());
+    // then
+    assertTrue(notification.getIsRead());
+  }
+
+  @Test
+  @DisplayName("회원의 알림이 없으면 예외가 발생한다.")
+  void updateNotification_shouldThrowExceptionWhenNotificationNotFound() {
+    // given
+    Long notificationId = 1L;
+    when(notificationRepository.findByIdAndMemberId(notificationId, member.getId())).thenReturn(
+        Optional.empty());
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> notificationService.updateNotification(notificationId, member.getId()));
+    // then
+    assertEquals(NOTIFICATION_NOT_FOUND, e.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("이미 읽은 상태의 알림의 읽음요청을 보내면 예외가 발생한다.")
+  void updateNotification_shouldThrowExceptionWhenNotificationAlreadyRead() {
+    // given
+    Long notificationId = 1L;
+    when(notificationRepository.findByIdAndMemberId(notificationId, member.getId())).thenReturn(
+        Optional.of(readNotification));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> notificationService.updateNotification(notificationId, member.getId()));
+    // then
+    assertEquals(ALREADY_READ, e.getErrorCode());
+  }
+}


### PR DESCRIPTION
## ⚡️ Issue 번호
<!-- 작업한 내용에 해당하는 Issue 번호를 꼭! 기록해주세요 !
키워드: close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved
예시: close #10 !-->
알림관련 https://github.com/ProjectGoGym/BackEnd/issues/5
## 🛠️ 작업 내용 (What)
- 알림 관련 기능 구현

## 📌 작업 이유 (Why)
- 회원이 올린 게시글에 찜이 추가 된경우 알림이 발송됩니다.
- 회원의 상태(경고 누적 등) 가 변경 될 경우 알림이 발송됩니다.
- 알림이 실시간으로 소통되기 위해 SSE 를 사용하고, 이를 통해 로그인된 경우 SSE 를 연결시킵니다.

## ✨ 변경 사항 (Changes)
- **공통**
  - GoGymApplication 실행 시 @EnableScheduling 추가했습니다.
  - Logging Pointcut 에 schedule  하위에 있는 메서드는 로그를 남기지 않는것으로 변경했습니다.
- SSE 관련
  - 클라이언트와 실시간 소통을 위해 SSE 구독 요청을 받습니다.
  - 구독 요청이 완료되면 더미 데이터를 보내 성공적인 연결 확인을 합니다.
  - 특수한 상황에서 연결이 끊어질 수 있어 지속적으로 연결중이라는 메세지를 전송합니다.
  - 로그아웃 된 상황, 시간 종료, 창 닫기, 에러 등 여러 상황에서 구독을 끊어 효율적인 관리를 합니다
- 알림 생성
  - 알림이 생성되면 알림 정보를 DB 에 저장하고 회원이 SSE 에 구독이 되어있는 경우에 알림을 전송합니다.
  - 회원이 구독되어있지 않은상태이더라도 DB 에 알림이 저장됩니다.
- 알림 조회
  - 회원이 읽지 않은 알림은 페이징처리 되어 확인이 가능합니다.
  - 만약 읽은 상태의 알림이라면, 조회 요청 시 조회가 되지 않습니다.
  - 읽지 않은 알림이 없으면 빈 배열이 반환됩니다.
- 알림 확인
  - 회원의 알림을 읽은 상태로 변경되면 isRead 필드가 true 로 변경되어 읽은상태로 변경됩니다.
  - 회원의 ID 나 요청한 알림 ID 가 없는 경우 예외가 발생합니다.

## ✅ 테스트 (Tests)
- [x]  구독을 신청한 회원은 Map 에 등록되어 관리된다.
- [x] 알림 생성 시 DB 에 저장된다.
- [x] 저장된 알림이 있고 읽지 않은 경우 알림이 조회된다.
- [x] 저장된 알림이 없는 경우 빈 배열을 반환한다.
- [x] 저장된 알림이 있고, 읽은 상태면 빈 배열을 반환한다.
- [x] 알림을 읽음 상태로 변경 요청이 오면 읽음 상태로 변경한다.
- [x] 회원의 알림이 없으면 예외가 발생한다,
- [x] 이미 읽은 상태의 알림의 읽음요청을 보내면 예외가 발생한다.

## 💬 리뷰 포인트 (Review Points)
- Controller 와 Service 에서 회원의 정보를 검증하는 부분(TODO) 은 추후 회원관련 설정이 완료되면 변경 예정입니다.
- 회원관련 로직이 완료되면 각 상황에 대한 예외처리(회원이 없다, 권한이 없다 등) 추가 예정입니다.
- 테스트코드 작성 시 SSE 관련은 Mock 데이터로 아무리 해도 확인이 어려워 추 후 클라이언트와 연결 테스트때 시도 해봐야할 부분인것 같습니다.
- Type 관련은 추후에 추가하거나 하면 좋을것 같습니다 혹시라도 추가하면 좋은 상태가 있다면 논의해보면 좋을 것 같습니다.

대신 구독 연결 테스트는 로컬에서 확인했습니다.
<img width="1840" alt="스크린샷 2024-11-27 오후 12 58 18" src="https://github.com/user-attachments/assets/59125728-4846-41b1-8592-84b15cf0d19e">
<img width="986" alt="스크린샷 2024-11-27 오후 12 59 16" src="https://github.com/user-attachments/assets/77f56dc6-1c4f-4b77-8eea-17743bbdd7c9">