### PR TITLE
✨ feat : 채팅 메시지 브로드캐스팅 및 Redis-DB 연계 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,10 +46,6 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-authorization-server'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
@@ -58,10 +54,22 @@ dependencies {
 
 	implementation "com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5"
 
+	implementation 'io.portone:server-sdk:0.10.0'
+
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	testImplementation 'it.ozimov:embedded-redis:0.7.3'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.batch:spring-batch-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+clean {
+ 	delete file('src/main/generated')
 }
 
 tasks.named('test') {

--- a/src/main/java/com/gogym/chat/controller/ChatController.java
+++ b/src/main/java/com/gogym/chat/controller/ChatController.java
@@ -1,5 +1,0 @@
-package com.gogym.chat.controller;
-
-public class ChatController {
-
-}

--- a/src/main/java/com/gogym/chat/controller/WebSocketChatController.java
+++ b/src/main/java/com/gogym/chat/controller/WebSocketChatController.java
@@ -31,7 +31,6 @@ public class WebSocketChatController {
    * @param request 송신 메시지 정보를 포함한 {@link ChatMessageRequest}.
    */
   @MessageMapping("/chatroom/message")
-  @SendTo("/topic/messages")
   public void send(@Valid ChatMessageRequest messageRequest) {
     // 메시지를 Redis에 저장
     ChatMessageResponse savedMessage = this.chatRedisService.saveMessageToRedis(messageRequest);

--- a/src/main/java/com/gogym/chat/controller/WebSocketChatController.java
+++ b/src/main/java/com/gogym/chat/controller/WebSocketChatController.java
@@ -1,7 +1,6 @@
 package com.gogym.chat.controller;
 
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 import com.gogym.chat.dto.ChatMessageDto.ChatMessageRequest;

--- a/src/main/java/com/gogym/chat/controller/WebSocketChatController.java
+++ b/src/main/java/com/gogym/chat/controller/WebSocketChatController.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Controller;
 import com.gogym.chat.dto.ChatMessageDto.ChatMessageRequest;
 import com.gogym.chat.dto.ChatMessageDto.ChatMessageResponse;
 import com.gogym.chat.service.ChatRedisService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -31,7 +32,7 @@ public class WebSocketChatController {
    */
   @MessageMapping("/chatroom/message")
   @SendTo("/topic/messages")
-  public void send(ChatMessageRequest messageRequest) {
+  public void send(@Valid ChatMessageRequest messageRequest) {
     // 메시지를 Redis에 저장
     ChatMessageResponse savedMessage = this.chatRedisService.saveMessageToRedis(messageRequest);
     

--- a/src/main/java/com/gogym/chat/controller/WebSocketChatController.java
+++ b/src/main/java/com/gogym/chat/controller/WebSocketChatController.java
@@ -1,0 +1,44 @@
+package com.gogym.chat.controller;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+import com.gogym.chat.dto.ChatMessageDto.ChatMessageRequest;
+import com.gogym.chat.dto.ChatMessageDto.ChatMessageResponse;
+import com.gogym.chat.service.ChatRedisService;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * WebSocket을 통한 실시간 채팅 메시지 처리를 담당하는 컨트롤러.
+ */
+@Controller
+@RequiredArgsConstructor
+public class WebSocketChatController {
+  
+  private static final String TOPIC_CHATROOM_PREFIX = "/topic/chatroom/";
+  
+  private final SimpMessagingTemplate messagingTemplate;
+  private final ChatRedisService chatRedisService;
+  
+  /**
+   * 실시간 채팅 메시지를 처리하고 Redis에 저장한 뒤,
+   * 해당 채팅방의 구독자에게 브로드캐스트합니다.
+   * 
+   * 클라이언트는 "/app/chatroom/message" 경로로 메시지를 보냅니다.
+   * 
+   * @param request 송신 메시지 정보를 포함한 {@link ChatMessageRequest}.
+   */
+  @MessageMapping("/chatroom/message")
+  @SendTo("/topic/messages")
+  public void send(ChatMessageRequest messageRequest) {
+    // 메시지를 Redis에 저장
+    ChatMessageResponse savedMessage = this.chatRedisService.saveMessageToRedis(messageRequest);
+    
+    // 메시지를 구독자에게 전송
+    this.messagingTemplate.convertAndSend(
+        TOPIC_CHATROOM_PREFIX + messageRequest.chatroomId(),
+        savedMessage);
+  }
+  
+}

--- a/src/main/java/com/gogym/chat/controller/WebSocketChatController.java
+++ b/src/main/java/com/gogym/chat/controller/WebSocketChatController.java
@@ -37,7 +37,7 @@ public class WebSocketChatController {
     
     // 메시지를 구독자에게 전송
     this.messagingTemplate.convertAndSend(
-        TOPIC_CHATROOM_PREFIX + messageRequest.chatroomId(),
+        TOPIC_CHATROOM_PREFIX + messageRequest.chatRoomId(),
         savedMessage);
   }
   

--- a/src/main/java/com/gogym/chat/dto/ChatDto.java
+++ b/src/main/java/com/gogym/chat/dto/ChatDto.java
@@ -1,5 +1,0 @@
-package com.gogym.chat.dto;
-
-public class ChatDto {
-
-}

--- a/src/main/java/com/gogym/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/gogym/chat/dto/ChatMessageDto.java
@@ -1,13 +1,15 @@
 package com.gogym.chat.dto;
 
 import java.time.LocalDateTime;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public class ChatMessageDto {
 
   public record ChatMessageRequest(
-      Long chatRoomId,
-      Long senderId,
-      String content) {}
+      @NotNull Long chatRoomId,
+      @NotNull Long senderId,
+      @NotBlank String content) {}
 
   public record ChatMessageResponse(
       Long chatRoomId,

--- a/src/main/java/com/gogym/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/gogym/chat/dto/ChatMessageDto.java
@@ -5,12 +5,12 @@ import java.time.LocalDateTime;
 public class ChatMessageDto {
 
   public record ChatMessageRequest(
-      Long chatroomId,
+      Long chatRoomId,
       Long senderId,
       String content) {}
 
   public record ChatMessageResponse(
-      Long chatroomId,
+      Long chatRoomId,
       Long senderId,
       String content,
       LocalDateTime createdAt) {}

--- a/src/main/java/com/gogym/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/gogym/chat/dto/ChatMessageDto.java
@@ -1,0 +1,23 @@
+package com.gogym.chat.dto;
+
+import java.time.LocalDateTime;
+
+public class ChatMessageDto {
+
+  public record ChatMessageRequest(
+      Long chatroomId,
+      Long senderId,
+      String content) {}
+
+  public record ChatMessageResponse(
+      Long chatroomId,
+      Long senderId,
+      String content,
+      LocalDateTime createdAt) {}
+
+  public record ChatMessageHistory(
+      String content,
+      Long senderId,
+      String createdAt) {}
+
+}

--- a/src/main/java/com/gogym/chat/dto/ChatRoomDto.java
+++ b/src/main/java/com/gogym/chat/dto/ChatRoomDto.java
@@ -1,6 +1,7 @@
 package com.gogym.chat.dto;
 
 import java.time.LocalDateTime;
+import jakarta.validation.constraints.NotNull;
 
 public class ChatRoomDto {
 
@@ -14,6 +15,6 @@ public class ChatRoomDto {
       String lastMessage,
       LocalDateTime lastMessageAt) {}
 
-  public record LeaveRequest(Long lastReadMessageId) {}
+  public record LeaveRequest(@NotNull Long lastReadMessageId) {}
 
 }

--- a/src/main/java/com/gogym/chat/dto/ChatRoomDto.java
+++ b/src/main/java/com/gogym/chat/dto/ChatRoomDto.java
@@ -1,0 +1,19 @@
+package com.gogym.chat.dto;
+
+import java.time.LocalDateTime;
+
+public class ChatRoomDto {
+
+  public record ChatRoomResponse(
+      Long chatRoomId,
+      LocalDateTime createdAt,
+      Long postId,
+      Long counterpartyId,
+      String counterpartyNickname,
+      int unreadMessageCount,
+      String lastMessage,
+      LocalDateTime lastMessageAt) {}
+
+  public record LeaveRequest(Long lastReadMessageId) {}
+
+}

--- a/src/main/java/com/gogym/chat/entity/ChatEntity.java
+++ b/src/main/java/com/gogym/chat/entity/ChatEntity.java
@@ -1,5 +1,0 @@
-package com.gogym.chat.entity;
-
-public class ChatEntity {
-
-}

--- a/src/main/java/com/gogym/chat/entity/ChatMessage.java
+++ b/src/main/java/com/gogym/chat/entity/ChatMessage.java
@@ -4,9 +4,6 @@ import com.gogym.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -17,17 +14,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "chat_message")
+@Table(name = "chat_messages")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class ChatMessage extends BaseEntity {
-  
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "message_id")
-  private Long id; // 메시지 ID
   
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "chat_room_id", nullable = false)

--- a/src/main/java/com/gogym/chat/entity/ChatMessage.java
+++ b/src/main/java/com/gogym/chat/entity/ChatMessage.java
@@ -1,0 +1,42 @@
+package com.gogym.chat.entity;
+
+import com.gogym.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "chat_message")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChatMessage extends BaseEntity {
+  
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "message_id")
+  private Long id; // 메시지 ID
+  
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "chat_room_id", nullable = false)
+  private ChatRoom chatRoom; // 메시지가 속한 채팅방
+  
+  @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+  private String content; // 메시지 내용
+  
+  @Column(name = "sender_id", nullable = false)
+  private Long senderId; // 메시지 보낸 사용자 ID (nullable)
+  
+}

--- a/src/main/java/com/gogym/chat/entity/ChatMessageRead.java
+++ b/src/main/java/com/gogym/chat/entity/ChatMessageRead.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "chat_message_read")
@@ -31,6 +32,7 @@ public class ChatMessageRead extends BaseEntity {
   
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "last_read_message")
+  @Setter
   private ChatMessage lastReadMessage; // 마지막으로 읽은 메시지
   
 }

--- a/src/main/java/com/gogym/chat/entity/ChatMessageRead.java
+++ b/src/main/java/com/gogym/chat/entity/ChatMessageRead.java
@@ -4,9 +4,6 @@ import com.gogym.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
@@ -24,11 +21,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class ChatMessageRead extends BaseEntity {
-  
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "read_id")
-  private Long id; // 읽음 상태 ID
   
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "chat_room_id", nullable = false)

--- a/src/main/java/com/gogym/chat/entity/ChatMessageRead.java
+++ b/src/main/java/com/gogym/chat/entity/ChatMessageRead.java
@@ -1,0 +1,44 @@
+package com.gogym.chat.entity;
+
+import com.gogym.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "chat_message_read")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChatMessageRead extends BaseEntity {
+  
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "read_id")
+  private Long id; // 읽음 상태 ID
+  
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "chat_room_id", nullable = false)
+  private ChatRoom chatRoom; // 읽음 상태를 관리하는 채팅방
+  
+  @Column(name = "member_id", nullable = false)
+  private Long memberId; // 메시지를 읽은 사용자 ID
+  
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "last_read_message")
+  private ChatMessage lastReadMessage; // 마지막으로 읽은 메시지
+  
+}

--- a/src/main/java/com/gogym/chat/entity/ChatRoom.java
+++ b/src/main/java/com/gogym/chat/entity/ChatRoom.java
@@ -3,9 +3,6 @@ package com.gogym.chat.entity;
 import com.gogym.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -14,17 +11,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "chatroom")
+@Table(name = "chatrooms")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class ChatRoom extends BaseEntity {
-  
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "chat_room_id")
-  private Long id; // 채팅방 ID
   
   @Column(name = "post_id", nullable = false)
   private Long postId; // 게시글 작성자 ID

--- a/src/main/java/com/gogym/chat/entity/ChatRoom.java
+++ b/src/main/java/com/gogym/chat/entity/ChatRoom.java
@@ -1,0 +1,38 @@
+package com.gogym.chat.entity;
+
+import com.gogym.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "chatroom")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChatRoom extends BaseEntity {
+  
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "chat_room_id")
+  private Long id; // 채팅방 ID
+  
+  @Column(name = "post_id", nullable = false)
+  private Long postId; // 게시글 작성자 ID
+  
+  @Column(name = "request_id", nullable = false)
+  private Long requestId; // 채팅 요청자 ID
+  
+  @Column(name = "is_deleted", nullable = false)
+  private Boolean isDeleted; // 삭제 여부
+  
+}

--- a/src/main/java/com/gogym/chat/repository/ChatMessageReadRepository.java
+++ b/src/main/java/com/gogym/chat/repository/ChatMessageReadRepository.java
@@ -1,0 +1,28 @@
+package com.gogym.chat.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import com.gogym.chat.entity.ChatMessageRead;
+import com.gogym.chat.entity.ChatRoom;
+
+public interface ChatMessageReadRepository extends JpaRepository<ChatMessageRead, Long> {
+  
+  // 특정 채팅방에서 특정 사용자가 읽은 마지막 메시지 조회
+  Optional<ChatMessageRead> findByChatRoomAndMemberId(ChatRoom chatRoom, Long memberId);
+  
+  @Query("""
+      SELECT COUNT(m)
+      FROM ChatMessage m
+      WHERE m.chatRoom.id = :chatRoomId
+        AND m.id > COALESCE(( 
+            SELECT r.lastReadMessage.id 
+            FROM ChatMessageRead r 
+            WHERE r.chatRoom.id = :chatRoomId 
+              AND r.memberId = :memberId 
+        ), 0)
+  """)
+  int countUnreadMessages(@Param("chatRoomId") Long chatRoomId, @Param("memberId") Long memberId);
+  
+}

--- a/src/main/java/com/gogym/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/gogym/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,18 @@
+package com.gogym.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import com.gogym.chat.entity.ChatMessage;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+  
+  @Query("""
+      SELECT m
+      FROM ChatMessage m
+      WHERE m.chatRoom.id = :chatRoomId
+      ORDER BY m.createdAt DESC
+  """)
+  ChatMessage findTopByChatRoomIdOrderByCreatedAtDesc(@Param("chatRoomId") Long chatRoomId);
+  
+}

--- a/src/main/java/com/gogym/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/gogym/chat/repository/ChatMessageRepository.java
@@ -2,18 +2,16 @@ package com.gogym.chat.repository;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import com.gogym.chat.entity.ChatMessage;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
   
-  @Query("""
-      SELECT m
-      FROM ChatMessage m
-      WHERE m.chatRoom.id = :chatRoomId
-      ORDER BY m.createdAt DESC
-  """)
-  Optional<ChatMessage> findTopByChatRoomIdOrderByCreatedAtDesc(@Param("chatRoomId") Long chatRoomId);
+  /**
+   * 특정 채팅방에서 가장 최근에 생성된 메시지를 조회합니다.
+   *
+   * @param chatRoomId 채팅방 ID
+   * @return 가장 최근의 메시지 (Optional)
+   */
+  Optional<ChatMessage> findFirstByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId);
   
 }

--- a/src/main/java/com/gogym/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/gogym/chat/repository/ChatMessageRepository.java
@@ -1,5 +1,6 @@
 package com.gogym.chat.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,6 +14,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
       WHERE m.chatRoom.id = :chatRoomId
       ORDER BY m.createdAt DESC
   """)
-  ChatMessage findTopByChatRoomIdOrderByCreatedAtDesc(@Param("chatRoomId") Long chatRoomId);
+  Optional<ChatMessage> findTopByChatRoomIdOrderByCreatedAtDesc(@Param("chatRoomId") Long chatRoomId);
   
 }

--- a/src/main/java/com/gogym/chat/repository/ChatRepository.java
+++ b/src/main/java/com/gogym/chat/repository/ChatRepository.java
@@ -1,5 +1,0 @@
-package com.gogym.chat.repository;
-
-public class ChatRepository {
-
-}

--- a/src/main/java/com/gogym/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/gogym/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,27 @@
+package com.gogym.chat.repository;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import com.gogym.chat.entity.ChatRoom;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+  
+  // 특정 게시글과 요청자의 채팅방 존재 여부 확인
+  boolean existsByPostIdAndRequestId(Long postId, Long requestId);
+  
+  // 사용자가 참여한 채팅방 목록 조회
+  @Query("""
+      SELECT c 
+      FROM ChatRoom c 
+      WHERE c.postId = :memberId OR c.requestId = :memberId
+  """)
+  Page<ChatRoom> findAllChatroomsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+  
+  // 사용자가 참여한 특정 채팅방 조회
+  Optional<ChatRoom> findByIdAndPostIdOrRequestId(Long chatRoomId, Long postId, Long requestId);
+  
+}

--- a/src/main/java/com/gogym/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/gogym/chat/repository/ChatRoomRepository.java
@@ -4,24 +4,37 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import com.gogym.chat.entity.ChatRoom;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
   
-  // 특정 게시글과 요청자의 채팅방 존재 여부 확인
+  /**
+   * 특정 게시글과 요청자의 채팅방 존재 여부 확인.
+   *
+   * @param postId 게시글 ID
+   * @param requestId 요청자 ID
+   * @return 채팅방 존재 여부
+   */
   boolean existsByPostIdAndRequestId(Long postId, Long requestId);
   
-  // 사용자가 참여한 채팅방 목록 조회
-  @Query("""
-      SELECT c 
-      FROM ChatRoom c 
-      WHERE c.postId = :memberId OR c.requestId = :memberId
-  """)
-  Page<ChatRoom> findAllChatroomsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+  /**
+   * 특정 사용자가 참여한 채팅방 목록 조회.
+   *
+   * @param postId 게시글 ID
+   * @param requestId 요청자 ID
+   * @param pageable 페이징 정보
+   * @return 참여한 채팅방 목록 (Page)
+   */
+  Page<ChatRoom> findByPostIdOrRequestId(Long postId, Long requestId, Pageable pageable);
   
-  // 사용자가 참여한 특정 채팅방 조회
+  /**
+   * 사용자가 참여한 특정 채팅방 조회.
+   *
+   * @param chatRoomId 채팅방 ID
+   * @param postId 게시글 ID
+   * @param requestId 요청자 ID
+   * @return 특정 채팅방 (Optional)
+   */
   Optional<ChatRoom> findByIdAndPostIdOrRequestId(Long chatRoomId, Long postId, Long requestId);
   
 }

--- a/src/main/java/com/gogym/chat/schedule/ChatMessageBatchScheduler.java
+++ b/src/main/java/com/gogym/chat/schedule/ChatMessageBatchScheduler.java
@@ -12,12 +12,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
+@Transactional
 @RequiredArgsConstructor
 public class ChatMessageBatchScheduler {
 

--- a/src/main/java/com/gogym/chat/schedule/ChatMessageBatchScheduler.java
+++ b/src/main/java/com/gogym/chat/schedule/ChatMessageBatchScheduler.java
@@ -39,6 +39,12 @@ public class ChatMessageBatchScheduler {
     Set<String> redisKeys = this.redisTemplate.keys(REDIS_CHATROOM_MESSAGE_KEY + "*");
 
     redisKeys.forEach(redisKey -> {
+      // Redis에서 메시지 가져오기
+      String messageJson = this.redisUtil.get(redisKey);
+      if (messageJson == null || messageJson.isEmpty()) {
+        return;
+      }
+
       // Redis Key에서 chatroomId 추출
       String chatroomIdStr = redisKey.replace(REDIS_CHATROOM_MESSAGE_KEY, "");
       Long chatroomId = Long.parseLong(chatroomIdStr);
@@ -46,12 +52,6 @@ public class ChatMessageBatchScheduler {
       // 채팅방 정보 조회
       ChatRoom chatRoom = this.chatRoomRepository.findById(chatroomId)
           .orElseThrow(() -> new CustomException(ErrorCode.CHATROOM_NOT_FOUND));
-
-      // Redis에서 메시지 가져오기
-      String messageJson = this.redisUtil.get(redisKey);
-      if (messageJson == null || messageJson.isEmpty()) {
-        return;
-      }
 
       // JSON 문자열을 ChatMessageHistory 객체로 역직렬화
       ChatMessageHistory messageHistory = deserializeMessageHistory(messageJson);

--- a/src/main/java/com/gogym/chat/schedule/ChatMessageBatchScheduler.java
+++ b/src/main/java/com/gogym/chat/schedule/ChatMessageBatchScheduler.java
@@ -1,0 +1,73 @@
+package com.gogym.chat.schedule;
+
+import com.gogym.chat.entity.ChatMessage;
+import com.gogym.chat.entity.ChatRoom;
+import com.gogym.chat.dto.ChatMessageDto.ChatMessageHistory;
+import com.gogym.chat.repository.ChatMessageRepository;
+import com.gogym.chat.repository.ChatRoomRepository;
+import com.gogym.exception.CustomException;
+import com.gogym.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class ChatMessageBatchScheduler {
+
+  private static final String REDIS_CHATROOM_MESSAGE_KEY = "chatroom:messages:";
+
+  private final ChatRoomRepository chatRoomRepository;
+  private final ChatMessageRepository chatMessageRepository;
+
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  /**
+   * 일정 주기로 Redis에 저장된 메시지를 DB로 저장.
+   * Redis에 저장된 메시지를 읽어서 DB에 저장한 뒤 Redis에서 해당 메시지를 삭제합니다.
+   */
+  @Scheduled(fixedRate = 300000)
+  public void batchMessagesToDatabase() {
+    Set<String> redisKeys = this.redisTemplate.keys(REDIS_CHATROOM_MESSAGE_KEY + "*");
+
+    redisKeys.forEach(redisKey -> {
+      // Redis Key에서 chatroomId 추출
+      String chatroomIdStr = redisKey.replace(REDIS_CHATROOM_MESSAGE_KEY, "");
+      Long chatroomId = Long.parseLong(chatroomIdStr);
+
+      // 채팅방 정보 조회
+      ChatRoom chatRoom = this.chatRoomRepository.findById(chatroomId)
+          .orElseThrow(() -> new CustomException(ErrorCode.CHATROOM_NOT_FOUND));
+
+      // Redis 메시지 가져오기
+      List<Object> messages = this.redisTemplate.opsForList().range(redisKey, 0, -1);
+      if (messages == null || messages.isEmpty()) {
+        return;
+      }
+
+      // Redis 메시지를 ChatMessage 엔티티로 변환
+      List<ChatMessage> chatMessages = messages.stream()
+          .filter(msg -> msg instanceof ChatMessageHistory)
+          .map(msg -> {
+            ChatMessageHistory history = (ChatMessageHistory) msg;
+            return ChatMessage.builder()
+                .chatRoom(chatRoom)
+                .content(history.content())
+                .senderId(history.senderId())
+                .build();
+          }).collect(Collectors.toList());
+
+      // DB에 저장
+      this.chatMessageRepository.saveAll(chatMessages);
+
+      // Redis 메시지 삭제
+      this.redisTemplate.delete(redisKey);
+    });
+  }
+}

--- a/src/main/java/com/gogym/chat/service/ChatRedisService.java
+++ b/src/main/java/com/gogym/chat/service/ChatRedisService.java
@@ -1,0 +1,16 @@
+package com.gogym.chat.service;
+
+import com.gogym.chat.dto.ChatMessageDto.ChatMessageRequest;
+import com.gogym.chat.dto.ChatMessageDto.ChatMessageResponse;
+
+public interface ChatRedisService {
+  
+  /**
+   * 메시지를 Redis에 저장 후 응답
+   * 
+   * @param messageRequest 요청 메시지
+   * @return 저장된 메시지 응답
+   */
+  ChatMessageResponse saveMessageToRedis(ChatMessageRequest messageRequest);
+
+}

--- a/src/main/java/com/gogym/chat/service/ChatRedisService.java
+++ b/src/main/java/com/gogym/chat/service/ChatRedisService.java
@@ -12,5 +12,12 @@ public interface ChatRedisService {
    * @return 저장된 메시지 응답
    */
   ChatMessageResponse saveMessageToRedis(ChatMessageRequest messageRequest);
+  
+  /**
+   * Redis에서 채팅방 메시지를 저장할 때 사용하는 키의 접두사를 반환
+   * 
+   * @return Redis에서 채팅방 메시지 키의 접두사를 나타내는 문자열
+   */
+  String getRedisChatroomMessageKeyPrefix();
 
 }

--- a/src/main/java/com/gogym/chat/service/ChatService.java
+++ b/src/main/java/com/gogym/chat/service/ChatService.java
@@ -1,5 +1,0 @@
-package com.gogym.chat.service;
-
-public class ChatService {
-
-}

--- a/src/main/java/com/gogym/chat/service/impl/ChatRedisServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRedisServiceImpl.java
@@ -4,15 +4,15 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import com.gogym.chat.dto.ChatMessageDto.ChatMessageHistory;
 import com.gogym.chat.dto.ChatMessageDto.ChatMessageRequest;
 import com.gogym.chat.dto.ChatMessageDto.ChatMessageResponse;
 import com.gogym.chat.service.ChatRedisService;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ChatRedisServiceImpl implements ChatRedisService {
 

--- a/src/main/java/com/gogym/chat/service/impl/ChatRedisServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRedisServiceImpl.java
@@ -28,7 +28,7 @@ public class ChatRedisServiceImpl implements ChatRedisService {
   @Override
   public ChatMessageResponse saveMessageToRedis(ChatMessageRequest messageRequest) {
     // Redis Key 생성
-    String redisKey = REDIS_CHATROOM_MESSAGE_KEY + messageRequest.chatroomId();
+    String redisKey = REDIS_CHATROOM_MESSAGE_KEY + messageRequest.chatRoomId();
 
     // LocalDateTime을 String으로 변환
     String createdAt = LocalDateTime.now().format(DATE_TIME_FORMATTER);
@@ -47,7 +47,7 @@ public class ChatRedisServiceImpl implements ChatRedisService {
 
     // 메시지 저장 결과 반환
     return new ChatMessageResponse(
-        messageRequest.chatroomId(),
+        messageRequest.chatRoomId(),
         messageRequest.senderId(),
         messageRequest.content(),
         LocalDateTime.parse(createdAt, DATE_TIME_FORMATTER));

--- a/src/main/java/com/gogym/chat/service/impl/ChatRedisServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRedisServiceImpl.java
@@ -1,0 +1,49 @@
+package com.gogym.chat.service.impl;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import com.gogym.chat.dto.ChatMessageDto.ChatMessageHistory;
+import com.gogym.chat.dto.ChatMessageDto.ChatMessageRequest;
+import com.gogym.chat.dto.ChatMessageDto.ChatMessageResponse;
+import com.gogym.chat.service.ChatRedisService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatRedisServiceImpl implements ChatRedisService {
+
+  private static final String REDIS_CHATROOM_MESSAGE_KEY = "chatroom:messages:";
+  private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+  private final RedisTemplate<String, Object> redisTemplate;
+
+  @Override
+  public ChatMessageResponse saveMessageToRedis(ChatMessageRequest messageRequest) {
+    // Redis Key 생성
+    String redisKey = REDIS_CHATROOM_MESSAGE_KEY + messageRequest.chatroomId();
+
+    // LocalDateTime을 String으로 변환
+    String createdAt = LocalDateTime.now().format(DATE_TIME_FORMATTER);
+
+    // Redis에 저장할 메시지 객체 생성
+    ChatMessageHistory messageHistory = new ChatMessageHistory(
+        messageRequest.content(),
+        messageRequest.senderId(),
+        createdAt);
+
+    // Redis 목록에 메시지 추가
+    this.redisTemplate.opsForList().rightPush(redisKey, messageHistory);
+
+    // 메시지 저장 결과 반환
+    return new ChatMessageResponse(
+        messageRequest.chatroomId(),
+        messageRequest.senderId(),
+        messageRequest.content(),
+        LocalDateTime.parse(createdAt, DATE_TIME_FORMATTER));
+  }
+
+}

--- a/src/main/java/com/gogym/chat/service/impl/ChatRedisServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRedisServiceImpl.java
@@ -53,6 +53,12 @@ public class ChatRedisServiceImpl implements ChatRedisService {
         LocalDateTime.parse(createdAt, DATE_TIME_FORMATTER));
   }
   
+  /**
+   * 주어진 ChatMessageHistory 객체를 JSON 문자열로 직렬화합니다.
+   * 
+   * @param messageHistory 직렬화할 ChatMessageHistory 객체
+   * @return 직렬화된 JSON 문자열
+   */
   private String serializeMessageHistory(ChatMessageHistory messageHistory) {
     try {
       ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/com/gogym/chat/service/impl/ChatRedisServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRedisServiceImpl.java
@@ -40,7 +40,7 @@ public class ChatRedisServiceImpl implements ChatRedisService {
     String messageJson = JsonUtil.serialize(messageHistory);
 
     // Redis에 저장
-    this.redisUtil.save(redisKey, messageJson, 3600);
+    this.redisUtil.lpush(redisKey, messageJson);
 
     // 메시지 저장 결과 반환
     return new ChatMessageResponse(

--- a/src/main/java/com/gogym/config/RedisConfig.java
+++ b/src/main/java/com/gogym/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.gogym.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+  @Bean
+  RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(connectionFactory);
+
+    // Key Serializer: String
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+
+    // Value Serializer: JSON
+    redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+    // Hash Key Serializer: String
+    redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+    // Hash Value Serializer: JSON
+    redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+    redisTemplate.afterPropertiesSet();
+    return redisTemplate;
+  }
+
+}

--- a/src/main/java/com/gogym/config/RedisConfig.java
+++ b/src/main/java/com/gogym/config/RedisConfig.java
@@ -1,34 +1,46 @@
 package com.gogym.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
 
+  @Value("${spring.data.redis.host}")
+  private String host;
+
+  @Value("${spring.data.redis.port}")
+  private String port;
+
   @Bean
-  RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
-    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-    redisTemplate.setConnectionFactory(connectionFactory);
-
-    // Key Serializer: String
-    redisTemplate.setKeySerializer(new StringRedisSerializer());
-
-    // Value Serializer: JSON
-    redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
-
-    // Hash Key Serializer: String
-    redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-
-    // Hash Value Serializer: JSON
-    redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
-
-    redisTemplate.afterPropertiesSet();
-    return redisTemplate;
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(host, Integer.parseInt(port));
   }
 
+  @Bean
+  public StringRedisTemplate redisTemplate(RedisConnectionFactory connectionFactory) {
+    return new StringRedisTemplate(connectionFactory);
+  }
+
+  @Bean
+  public RedisCacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+    RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+        .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(
+            new StringRedisSerializer()))
+        .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+            RedisSerializer.json()));
+
+    return RedisCacheManager.builder(redisConnectionFactory)
+        .cacheDefaults(cacheConfiguration)
+        .build();
+  }
 }

--- a/src/main/java/com/gogym/config/RedisConfig.java
+++ b/src/main/java/com/gogym/config/RedisConfig.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.RedisSerializer;
@@ -25,9 +26,20 @@ public class RedisConfig {
   public RedisConnectionFactory redisConnectionFactory() {
     return new LettuceConnectionFactory(host, Integer.parseInt(port));
   }
+  
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(connectionFactory);
+
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(RedisSerializer.json());
+
+    return redisTemplate;
+  }
 
   @Bean
-  public StringRedisTemplate redisTemplate(RedisConnectionFactory connectionFactory) {
+  public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
     return new StringRedisTemplate(connectionFactory);
   }
 

--- a/src/main/java/com/gogym/config/WebSocketConfig.java
+++ b/src/main/java/com/gogym/config/WebSocketConfig.java
@@ -1,0 +1,27 @@
+package com.gogym.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+  
+  @Override
+  public void configureMessageBroker(MessageBrokerRegistry config) {
+    // 클라이언트가 메시지를 받을 경로(prefix)
+    config.enableSimpleBroker("/topic", "/queue");
+    // 클라이언트가 메시지를 보낼 경로(prefix)
+    config.setApplicationDestinationPrefixes("/app");
+  }
+  
+  @Override
+  public void registerStompEndpoints(StompEndpointRegistry registry) {
+    // WebSocket 연결 endpoint 설정(SockJS 사용)
+    registry.addEndpoint("/ws").setAllowedOriginPatterns("http://localhost:3000").withSockJS();
+  }
+  
+}

--- a/src/main/java/com/gogym/exception/ErrorCode.java
+++ b/src/main/java/com/gogym/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
   CHATROOM_NOT_FOUND(NOT_FOUND, "채팅방을 찾을 수 없습니다."),
   CHAT_MESSAGE_NOT_FOUND(NOT_FOUND, "채팅 메시지를 찾을 수 없습니다."),
   CITY_NOT_FOUND(NOT_FOUND, "도시를 찾을 수 없습니다."),
+  DISTRICT_NOT_FOUND(NOT_FOUND, "지역을 찾을 수 없습니다."),
   GYM_PAY_NOT_FOUND(NOT_FOUND, "짐페이를 찾을 수 없습니다. 짐페이를 개설해주세요."),
   PAYMENT_NOT_FOUND(NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
 
@@ -42,6 +43,7 @@ public enum ErrorCode {
 
   // 500 INTERNAL SERVER ERROR
   JSON_MAPPING_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "JSON 변환 중 오류가 발생했습니다."),
+  PORTONE_API_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "포트원 API 호출 중 오류가 발생했습니다."),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/gogym/exception/ErrorCode.java
+++ b/src/main/java/com/gogym/exception/ErrorCode.java
@@ -29,6 +29,10 @@ public enum ErrorCode {
   MEMBER_NOT_FOUND(NOT_FOUND, "회원을 찾을 수 없습니다."),
   NOTIFICATION_NOT_FOUND(NOT_FOUND, "알림을 찾을 수 없습니다."),
   CHATROOM_NOT_FOUND(NOT_FOUND, "채팅방을 찾을 수 없습니다."),
+  CHAT_MESSAGE_NOT_FOUND(NOT_FOUND, "채팅 메시지를 찾을 수 없습니다."),
+  CITY_NOT_FOUND(NOT_FOUND, "도시를 찾을 수 없습니다."),
+  GYM_PAY_NOT_FOUND(NOT_FOUND, "짐페이를 찾을 수 없습니다. 짐페이를 개설해주세요."),
+  PAYMENT_NOT_FOUND(NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
 
   // 409 CONFLICT
   DUPLICATE_EMAIL(CONFLICT, "이미 사용 중인 이메일입니다."),

--- a/src/main/java/com/gogym/exception/ErrorCode.java
+++ b/src/main/java/com/gogym/exception/ErrorCode.java
@@ -1,8 +1,6 @@
 package com.gogym.exception;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.CONFLICT;
-import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.*;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +17,7 @@ public enum ErrorCode {
   UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
   EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
-  EMAIL_NOT_VERIFIED(NOT_FOUND, "이메일 인증이 완료되지 않았습니다."),
+  EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "이메일 인증이 완료되지 않았습니다."),
 
   // 403 FORBIDDEN
   FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),

--- a/src/main/java/com/gogym/exception/ErrorCode.java
+++ b/src/main/java/com/gogym/exception/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
   CHATROOM_ALREADY_EXISTS(CONFLICT, "이미 존재하는 채팅방입니다."),
 
   // 500 INTERNAL SERVER ERROR
+  JSON_MAPPING_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "JSON 변환 중 오류가 발생했습니다."),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
 
   private final HttpStatus httpStatus;

--- a/src/main/java/com/gogym/exception/ErrorResponse.java
+++ b/src/main/java/com/gogym/exception/ErrorResponse.java
@@ -7,6 +7,8 @@ public record ErrorResponse(
   public static ErrorResponse from(ErrorCode errorCode) {
     return new ErrorResponse(errorCode.name(), errorCode.getMessage());
   }
+
+  public static ErrorResponse withMessage(ErrorCode errorCode, String message) {
+    return new ErrorResponse(errorCode.name(), message);
+  }
 }
-
-

--- a/src/main/java/com/gogym/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gogym/exception/GlobalExceptionHandler.java
@@ -1,12 +1,13 @@
 package com.gogym.exception;
 
-import jakarta.servlet.http.HttpServletRequest;
-import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
@@ -46,7 +47,8 @@ public class GlobalExceptionHandler {
   }
 
   @ExceptionHandler(ConstraintViolationException.class)
-  public ResponseEntity<ErrorResponse> handleConstraintViolationException(HttpServletRequest request, ConstraintViolationException e) {
+  public ResponseEntity<ErrorResponse> handleConstraintViolationException(
+      HttpServletRequest request, ConstraintViolationException e) {
     String errorMessage = e.getMessage();
     String requestURI = request.getRequestURI();
 
@@ -55,6 +57,20 @@ public class GlobalExceptionHandler {
     log.error("ConstraintViolationException: {}, Request URI: {}", errorMessage, requestURI);
 
     return ResponseEntity.ok(response);
+  }
+  
+  @ExceptionHandler(WebClientResponseException.class)
+  public ResponseEntity<ErrorResponse> handleWebClientResponseException(
+      HttpServletRequest request, WebClientResponseException e) {
+    String errorMessage = e.getResponseBodyAsString();
+    String requestURI = request.getRequestURI();
+
+    ErrorResponse response = ErrorResponse.withMessage(ErrorCode.PORTONE_API_CALL_FAILED, errorMessage);
+
+    log.error("WebClientResponseException: {}, Status: {}, Request URI: {}", errorMessage,
+        e.getStatusCode(), requestURI);
+
+    return ResponseEntity.status(e.getStatusCode()).body(response);
   }
 }
 

--- a/src/main/java/com/gogym/util/JsonUtil.java
+++ b/src/main/java/com/gogym/util/JsonUtil.java
@@ -1,0 +1,48 @@
+package com.gogym.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.gogym.exception.CustomException;
+import com.gogym.exception.ErrorCode;
+
+public class JsonUtil {
+  
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  
+  static {
+    OBJECT_MAPPER.findAndRegisterModules();
+    OBJECT_MAPPER.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+  }
+  
+  /**
+   * 객체를 JSON 문자열로 직렬화합니다.
+   *
+   * @param object 직렬화할 객체
+   * @return 직렬화된 JSON 문자열
+   */
+  public static String serialize(Object object) {
+      try {
+          return OBJECT_MAPPER.writeValueAsString(object);
+      } catch (JsonProcessingException e) {
+          throw new CustomException(ErrorCode.JSON_MAPPING_FAILURE);
+      }
+  }
+  
+  /**
+   * JSON 문자열을 특정 클래스 타입의 객체로 역직렬화합니다.
+   *
+   * @param <T> 대상 클래스 타입
+   * @param json 역직렬화할 JSON 문자열
+   * @param valueType 역직렬화 대상 클래스
+   * @return 역직렬화된 객체
+   */
+  public static <T> T deserialize(String json, Class<T> valueType) {
+      try {
+          return OBJECT_MAPPER.readValue(json, valueType);
+      } catch (JsonProcessingException e) {
+          throw new CustomException(ErrorCode.JSON_MAPPING_FAILURE);
+      }
+  }
+  
+}

--- a/src/main/java/com/gogym/util/RedisUtil.java
+++ b/src/main/java/com/gogym/util/RedisUtil.java
@@ -1,0 +1,25 @@
+package com.gogym.util;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+
+  private final StringRedisTemplate redisTemplate;
+
+  public void save(String key, String value, long ttl) {
+    redisTemplate.opsForValue().set(key, value, Duration.ofSeconds(ttl));
+  }
+
+  public String get(String key) {
+    return redisTemplate.opsForValue().get(key);
+  }
+
+  public void delete(String key) {
+    redisTemplate.delete(key);
+  }
+}

--- a/src/main/java/com/gogym/util/RedisUtil.java
+++ b/src/main/java/com/gogym/util/RedisUtil.java
@@ -1,9 +1,10 @@
 package com.gogym.util;
 
 import java.time.Duration;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
@@ -22,4 +23,13 @@ public class RedisUtil {
   public void delete(String key) {
     redisTemplate.delete(key);
   }
+  
+  public void lpush(String key, String value) {
+    redisTemplate.opsForList().leftPush(key, value);
+  }
+
+  public List<String> lrange(String key, long start, long end) {
+    return redisTemplate.opsForList().range(key, start, end);
+  }
+  
 }

--- a/src/main/java/com/gogym/util/RedisUtil.java
+++ b/src/main/java/com/gogym/util/RedisUtil.java
@@ -32,4 +32,20 @@ public class RedisUtil {
     return redisTemplate.opsForList().range(key, start, end);
   }
   
+  public boolean addToSet(String key, String value, long ttl) {
+    Long result = redisTemplate.opsForSet().add(key, value);
+    if (result == 0) {
+      return false;
+    }
+
+    setTTL(key, ttl);
+    return true;
+  }
+
+  public void setTTL(String key, long ttl) {
+    if (redisTemplate.getExpire(key) == -1) {
+      redisTemplate.expire(key, Duration.ofSeconds(ttl));
+    }
+  }
+  
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,3 +41,5 @@ jasypt:
 
 portone:
   secret: ENC(Yae9m6UdFdavIg+60o/aoAP5jG7K4gwTIIy/I8FLCsp8PYOcIb0sfwr3wd8Z37XGke+83s1e4VTEv9OtMwV3wmnOWTeXJJ1JqxmGc8VKHFzyR6FJ4YoSPfwKjsBrUwB1)
+  webhook:
+    secret: ENC(rNgfIF0802rxis0Md6mRpdGH3WpdHA7XxabMdLFZXV6TWgeXAyUjfsFdffaqMBOfJlKSro6UCy3Krc2nOUfRNw==)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,3 +38,6 @@ logging:
 jasypt:
   encryptor:
     password: ${JASYPT_ENCRYPTOR_PASSWORD}
+
+portone:
+  secret: ENC(Yae9m6UdFdavIg+60o/aoAP5jG7K4gwTIIy/I8FLCsp8PYOcIb0sfwr3wd8Z37XGke+83s1e4VTEv9OtMwV3wmnOWTeXJJ1JqxmGc8VKHFzyR6FJ4YoSPfwKjsBrUwB1)

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
     </appender>
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>logs/app.log</file>
+        <file>/home/ubuntu/logs/app.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>logs/app.%d{yyyy-MM-dd}.log</fileNamePattern>

--- a/src/test/java/com/gogym/chat/service/impl/ChatMessageBatchSchedulerTest.java
+++ b/src/test/java/com/gogym/chat/service/impl/ChatMessageBatchSchedulerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -53,16 +54,15 @@ class ChatMessageBatchSchedulerTest {
     // Given
     Long chatroomId = 1L;
     String redisKey = "chatroom:messages:1";
+    String mockMessageJson = "{\"content\":\"안녕하세요!\",\"senderId\":123,\"createdAt\":\"2024-12-03 12:00:00\"}";
 
     ChatRoom mockChatRoom = mock(ChatRoom.class);
-    String mockMessageJson =
-        "{\"content\":\"안녕하세요!\",\"senderId\":123,\"createdAt\":\"2024-12-03 12:00:00\"}";
 
     // RedisTemplate Mock 설정
     when(this.redisTemplate.keys("chatroom:messages:*")).thenReturn(Set.of(redisKey));
 
     // RedisUtil Mock 설정
-    when(this.redisUtil.get(redisKey)).thenReturn(mockMessageJson);
+    when(this.redisUtil.lrange(redisKey, 0, -1)).thenReturn(List.of(mockMessageJson));
 
     // ChatRoomRepository Mock 설정
     when(this.chatRoomRepository.findById(chatroomId)).thenReturn(Optional.of(mockChatRoom));
@@ -93,7 +93,7 @@ class ChatMessageBatchSchedulerTest {
     when(this.redisTemplate.keys("chatroom:messages:*")).thenReturn(Set.of(redisKey));
 
     // RedisUtil Mock 설정
-    when(this.redisUtil.get(redisKey)).thenReturn(validMessageJson);
+    when(this.redisUtil.lrange(redisKey, 0, -1)).thenReturn(List.of(validMessageJson));
 
     // ChatRoomRepository Mock 설정
     when(this.chatRoomRepository.findById(chatroomId)).thenReturn(Optional.empty());
@@ -111,7 +111,7 @@ class ChatMessageBatchSchedulerTest {
     when(this.redisTemplate.keys("chatroom:messages:*")).thenReturn(Set.of(redisKey));
 
     // RedisUtil Mock 설정 (Redis에 메시지가 없는 상황)
-    when(this.redisUtil.get(redisKey)).thenReturn(null);
+    when(this.redisUtil.lrange(redisKey, 0, -1)).thenReturn(List.of()); // 빈 리스트 반환
 
     // When
     assertDoesNotThrow(() -> this.chatMessageBatchScheduler.batchMessagesToDatabase());

--- a/src/test/java/com/gogym/chat/service/impl/ChatMessageBatchSchedulerTest.java
+++ b/src/test/java/com/gogym/chat/service/impl/ChatMessageBatchSchedulerTest.java
@@ -1,0 +1,73 @@
+package com.gogym.chat.service.impl;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import com.gogym.chat.dto.ChatMessageDto.ChatMessageHistory;
+import com.gogym.chat.entity.ChatRoom;
+import com.gogym.chat.repository.ChatMessageRepository;
+import com.gogym.chat.repository.ChatRoomRepository;
+import com.gogym.chat.schedule.ChatMessageBatchScheduler;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageBatchSchedulerTest {
+  
+  @Mock
+  private RedisTemplate<String, Object> redisTemplate;
+
+  @Mock
+  private ChatRoomRepository chatRoomRepository;
+
+  @Mock
+  private ChatMessageRepository chatMessageRepository;
+  
+  @Mock
+  private ListOperations<String, Object> listOperations;
+
+  @InjectMocks
+  private ChatMessageBatchScheduler chatMessageBatchScheduler;
+  
+  @Test
+  public void 메시지를_Redis에_저장하고_삭제() {
+    // Given
+    String redisKey = "chatroom:messages:1";
+    Long chatroomId = 1L;
+
+    String content = "안녕하세요!";
+    Long senderId = 123L;
+    String createdAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+
+    ChatRoom mockChatRoom = mock(ChatRoom.class);
+    ChatMessageHistory messageHistory = new ChatMessageHistory(
+        content,
+        senderId,
+        createdAt);
+
+    when(this.redisTemplate.keys("chatroom:messages:*")).thenReturn(Set.of(redisKey));
+    when(this.redisTemplate.opsForList()).thenReturn(this.listOperations);
+    when(this.redisTemplate.opsForList().range(redisKey, 0, -1)).thenReturn(List.of(messageHistory));
+    when(this.chatRoomRepository.findById(chatroomId)).thenReturn(Optional.of(mockChatRoom));
+
+    // When
+    this.chatMessageBatchScheduler.batchMessagesToDatabase();
+
+    // Then
+    verify(this.chatMessageRepository, times(1)).saveAll(anyList());
+    verify(this.redisTemplate, times(1)).delete(redisKey);
+  }
+  
+}

--- a/src/test/java/com/gogym/chat/service/impl/ChatMessageBatchSchedulerTest.java
+++ b/src/test/java/com/gogym/chat/service/impl/ChatMessageBatchSchedulerTest.java
@@ -1,31 +1,38 @@
 package com.gogym.chat.service.impl;
 
-import static org.mockito.ArgumentMatchers.anyList;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.RedisTemplate;
-import com.gogym.chat.dto.ChatMessageDto.ChatMessageHistory;
+import com.gogym.chat.entity.ChatMessage;
 import com.gogym.chat.entity.ChatRoom;
 import com.gogym.chat.repository.ChatMessageRepository;
 import com.gogym.chat.repository.ChatRoomRepository;
 import com.gogym.chat.schedule.ChatMessageBatchScheduler;
+import com.gogym.exception.CustomException;
+import com.gogym.util.RedisUtil;
 
 @ExtendWith(MockitoExtension.class)
 class ChatMessageBatchSchedulerTest {
-  
+
+  @Mock
+  private RedisUtil redisUtil;
+
   @Mock
   private RedisTemplate<String, Object> redisTemplate;
 
@@ -34,40 +41,85 @@ class ChatMessageBatchSchedulerTest {
 
   @Mock
   private ChatMessageRepository chatMessageRepository;
-  
+
   @Mock
   private ListOperations<String, Object> listOperations;
 
   @InjectMocks
   private ChatMessageBatchScheduler chatMessageBatchScheduler;
-  
-  @Test
-  public void 메시지를_Redis에_저장하고_삭제() {
-    // Given
-    String redisKey = "chatroom:messages:1";
-    Long chatroomId = 1L;
 
-    String content = "안녕하세요!";
-    Long senderId = 123L;
-    String createdAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+  @Test
+  public void 메시지를_Redis에서_읽어_DB에_저장하고_삭제() {
+    // Given
+    Long chatroomId = 1L;
+    String redisKey = "chatroom:messages:1";
 
     ChatRoom mockChatRoom = mock(ChatRoom.class);
-    ChatMessageHistory messageHistory = new ChatMessageHistory(
-        content,
-        senderId,
-        createdAt);
+    String mockMessageJson =
+        "{\"content\":\"안녕하세요!\",\"senderId\":123,\"createdAt\":\"2024-12-03 12:00:00\"}";
 
+    // RedisTemplate Mock 설정
     when(this.redisTemplate.keys("chatroom:messages:*")).thenReturn(Set.of(redisKey));
-    when(this.redisTemplate.opsForList()).thenReturn(this.listOperations);
-    when(this.redisTemplate.opsForList().range(redisKey, 0, -1)).thenReturn(List.of(messageHistory));
+
+    // RedisUtil Mock 설정
+    when(this.redisUtil.get(redisKey)).thenReturn(mockMessageJson);
+
+    // ChatRoomRepository Mock 설정
     when(this.chatRoomRepository.findById(chatroomId)).thenReturn(Optional.of(mockChatRoom));
 
     // When
     this.chatMessageBatchScheduler.batchMessagesToDatabase();
 
     // Then
-    verify(this.chatMessageRepository, times(1)).saveAll(anyList());
-    verify(this.redisTemplate, times(1)).delete(redisKey);
+    ArgumentCaptor<ChatMessage> chatMessageCaptor = ArgumentCaptor.forClass(ChatMessage.class);
+    verify(this.chatMessageRepository, times(1)).save(chatMessageCaptor.capture());
+
+    ChatMessage savedMessage = chatMessageCaptor.getValue();
+    assertEquals("안녕하세요!", savedMessage.getContent());
+    assertEquals(123L, savedMessage.getSenderId());
+    assertEquals(mockChatRoom, savedMessage.getChatRoom());
+
+    verify(this.redisUtil, times(1)).delete(redisKey);
   }
-  
+
+  @Test
+  public void 채팅방이_존재하지_않는_경우_CustomException_발생() {
+    // Given
+    Long chatroomId = 1L;
+    String redisKey = "chatroom:messages:1";
+    String validMessageJson = "{\"content\":\"Hello\",\"senderId\":123,\"createdAt\":\"2024-12-03T12:00:00\"}";
+
+    // RedisTemplate Mock 설정
+    when(this.redisTemplate.keys("chatroom:messages:*")).thenReturn(Set.of(redisKey));
+
+    // RedisUtil Mock 설정
+    when(this.redisUtil.get(redisKey)).thenReturn(validMessageJson);
+
+    // ChatRoomRepository Mock 설정
+    when(this.chatRoomRepository.findById(chatroomId)).thenReturn(Optional.empty());
+
+    // When & Then
+    assertThrows(CustomException.class, () -> this.chatMessageBatchScheduler.batchMessagesToDatabase());
+  }
+
+  @Test
+  public void Redis에_메시지가_없는_경우_아무_작업도_하지_않음() {
+    // Given
+    String redisKey = "chatroom:messages:1";
+
+    // RedisTemplate Mock 설정
+    when(this.redisTemplate.keys("chatroom:messages:*")).thenReturn(Set.of(redisKey));
+
+    // RedisUtil Mock 설정 (Redis에 메시지가 없는 상황)
+    when(this.redisUtil.get(redisKey)).thenReturn(null);
+
+    // When
+    assertDoesNotThrow(() -> this.chatMessageBatchScheduler.batchMessagesToDatabase());
+
+    // Then
+    verify(this.chatRoomRepository, times(0)).findById(anyLong());
+    verify(this.chatMessageRepository, times(0)).save(any(ChatMessage.class));
+    verify(this.redisUtil, times(0)).delete(redisKey);
+  }
+
 }


### PR DESCRIPTION
## ⚡️ Issue 번호
<!-- 작업한 내용에 해당하는 Issue 번호를 꼭! 기록해주세요 !
키워드: close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved
예시: close #10 !-->
채팅 관련 https://github.com/ProjectGoGym/BackEnd/issues/4

## 🛠️ 작업 내용 (What)
- WebSocket STOMP 기반 메시지 브로드캐스팅 구현:
  - 클라이언트가 /app/chatroom/message 경로로 메시지를 전송하면, 이를 처리하고 Redis에 저장한 뒤 구독자에게 브로드캐스팅.
- Redis를 활용한 메시지 임시 저장 및 배치 처리:
  - 채팅 메시지를 Redis에 저장한 후, 일정 주기로 DB로 배치 처리.
- SimpMessagingTemplate을 통한 구독자 브로드캐스팅:
  - 저장된 메시지를 채팅방 구독자(/topic/chatroom/{chatRoomId})에게 전달.

## 📌 작업 이유 (Why)
- 실시간 채팅 지원:
  - 채팅방 내 사용자 간의 메시지를 실시간으로 전달하기 위해 WebSocket STOMP 프로토콜 사용.
- 효율적인 메시지 관리:
  - Redis를 활용해 실시간 메시지를 임시 저장하고, 일정 주기로 DB에 영구 저장하여 데이터 영속성 보장.
- 구독 기반 메시징 처리:
  - STOMP의 구독 모델을 활용해 클라이언트가 특정 채팅방에만 메시지를 수신하도록 처리.

## ✨ 변경 사항 (Changes)
- WebSocket 관련
  - WebSocketChatController 추가:
    - 클라이언트 메시지를 처리하는 STOMP 기반 컨트롤러 구현.
    - /app/chatroom/message 경로로 메시지를 수신하고 Redis에 저장.
    - /topic/chatroom/{chatRoomId} 경로를 구독 중인 클라이언트에게 메시지 브로드캐스트.
  - WebSocketConfig 설정:
    - /ws 엔드포인트를 통해 WebSocket 연결을 지원.
    - SockJS 대체 경로 제공.
    - 메시지 브로커 구성:
      - 클라이언트로부터 수신: /app.
      - 클라이언트로 전송: /topic.
- Redis 및 DB 관련
  - Redis 임시 저장:
    - ChatRedisService를 통해 메시지를 Redis에 저장.
    - Redis에 저장된 메시지에는 전송 시간, 메시지 내용, 송신자 ID 포함.
  - DB 배치 처리:
    - ChatMessageBatchScheduler를 통해 Redis에 저장된 메시지를 일정 주기로 DB에 배치 저장.
    - 저장된 메시지는 Redis에서 삭제하여 메모리 사용량을 최적화.

## ✅ 테스트 (Tests)
- [x] /app/chatroom/message 경로로 메시지를 전송하면 Redis에 메시지가 저장되는가?
- [x] 저장된 메시지가 /topic/chatroom/{chatRoomId} 구독자에게 브로드캐스팅되는가?
- [x] 클라이언트가 잘못된 채팅방 ID를 전달할 경우 적절한 예외가 발생하는가?
- [x] Redis에 저장된 메시지가 DB로 배치 처리되는가?
- [x] DB로 저장된 메시지가 Redis에서 삭제되는가?
- [x] Redis와 DB의 배치 처리 로직 통합 테스트를 통해 데이터 손실 없이 처리되는가?

## 💬 리뷰 포인트 (Review Points)
- Redis에 메시지가 저장되고, 배치 처리로 DB에 영구 저장되는 로직이 효율적인지 검토 부탁드립니다.
- WebSocket과 Redis의 통합 테스트는 로컬 환경에서는 확인했으며, 추후에 클라이언트와의 연결 테스트가 필요합니다.

![image](https://github.com/user-attachments/assets/df0ae83f-2a74-4a6c-9652-c50d07e8070c)