### PR TITLE
♻️refactor : 알림 및 게시글 회원 정보(토큰) 가져오기 변경

### DIFF
--- a/src/main/java/com/gogym/aop/LoggingAspect.java
+++ b/src/main/java/com/gogym/aop/LoggingAspect.java
@@ -15,7 +15,7 @@ public class LoggingAspect {
   @Pointcut("execution(* com.gogym..controller..*(..))")
   public void apiLayer() {}
 
-  @Pointcut("execution(* com.gogym..service..*(..)) && !execution(* com.gogym..schedule..*(..))")
+  @Pointcut("execution(* com.gogym..service..*(..)) && !execution(* com.gogym..schedule..*(..)) && !execution(* com.gogym.notification.service.NotificationService.getEmitters(..))")
   public void serviceLayer() {}
 
   @Around("apiLayer()")

--- a/src/main/java/com/gogym/member/jwt/SecurityConfig.java
+++ b/src/main/java/com/gogym/member/jwt/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig {
             "/api/auth/check-nickname",
             "/api/auth/verify-email",
             "/api/auth/reset-password",
-            "/api/auth/send-verification-email"
+            "/api/auth/send-verification-email",
+            "/api/regions"
             ).permitAll()
         // 그 외의 모든 요청은 인증 필요
         .anyRequest().authenticated()

--- a/src/main/java/com/gogym/member/service/AuthService.java
+++ b/src/main/java/com/gogym/member/service/AuthService.java
@@ -8,6 +8,7 @@ import com.gogym.member.dto.SignUpRequest;
 import com.gogym.member.entity.Member;
 import com.gogym.member.jwt.JwtTokenProvider;
 import com.gogym.member.repository.MemberRepository;
+import com.gogym.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -30,6 +31,7 @@ public class AuthService {
   private final PasswordEncoder passwordEncoder;
   private final JwtTokenProvider jwtTokenProvider;
   private final RedisTemplate<String, String> redisTemplate;
+  private final NotificationService notificationService;
   
   //회원가입 처리
   @Transactional
@@ -90,6 +92,7 @@ public class AuthService {
 
   // 로그아웃 처리
   public void logout(Long memberId) {
+    notificationService.removeEmitter(memberId);
     redisTemplate.opsForValue().set("logout:" + memberId, "logout", 600000, TimeUnit.MILLISECONDS);
   }
 

--- a/src/main/java/com/gogym/member/service/AuthService.java
+++ b/src/main/java/com/gogym/member/service/AuthService.java
@@ -2,22 +2,21 @@ package com.gogym.member.service;
 
 import com.gogym.exception.CustomException;
 import com.gogym.exception.ErrorCode;
+import com.gogym.member.dto.LoginResponse;
 import com.gogym.member.dto.ResetPasswordRequest;
 import com.gogym.member.dto.SignInRequest;
 import com.gogym.member.dto.SignUpRequest;
 import com.gogym.member.entity.Member;
 import com.gogym.member.jwt.JwtTokenProvider;
 import com.gogym.member.repository.MemberRepository;
-import com.gogym.notification.service.NotificationService;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import org.springframework.security.core.Authentication;
-import com.gogym.member.dto.LoginResponse;
 
 @Service
 @RequiredArgsConstructor
@@ -31,8 +30,7 @@ public class AuthService {
   private final PasswordEncoder passwordEncoder;
   private final JwtTokenProvider jwtTokenProvider;
   private final RedisTemplate<String, String> redisTemplate;
-  private final NotificationService notificationService;
-  
+
   //회원가입 처리
   @Transactional
   public void signUp(SignUpRequest request) {
@@ -92,7 +90,6 @@ public class AuthService {
 
   // 로그아웃 처리
   public void logout(Long memberId) {
-    notificationService.removeEmitter(memberId);
     redisTemplate.opsForValue().set("logout:" + memberId, "logout", 600000, TimeUnit.MILLISECONDS);
   }
 

--- a/src/main/java/com/gogym/notification/controller/NotificationController.java
+++ b/src/main/java/com/gogym/notification/controller/NotificationController.java
@@ -2,6 +2,7 @@ package com.gogym.notification.controller;
 
 import static org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE;
 
+import com.gogym.common.annotation.LoginMemberId;
 import com.gogym.notification.dto.NotificationDto;
 import com.gogym.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
@@ -22,18 +23,15 @@ public class NotificationController {
 
   private final NotificationService notificationService;
 
-  // TODO : 파라미터로 memberId 를 받는것이 아닌 token 으로 받는것으로 수정 {member-id} 제거
-  @GetMapping(value = "/subscribe/{member-id}", produces = TEXT_EVENT_STREAM_VALUE)
-  public SseEmitter subscribe(@PathVariable("member-id") Long memberId) {
+  @GetMapping(value = "/subscribe", produces = TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter subscribe(@LoginMemberId Long memberId) {
 
     return notificationService.subscribe(memberId);
   }
 
   @GetMapping
-  public ResponseEntity<Page<NotificationDto>> getAllNotifications(Pageable pageable) {
-
-    // TODO : 하드코딩 추후 변경
-    Long memberId = 1L;
+  public ResponseEntity<Page<NotificationDto>> getAllNotifications(@LoginMemberId Long memberId,
+      Pageable pageable) {
 
     Page<NotificationDto> notifications = notificationService.getAllNotifications(memberId,
         pageable);
@@ -42,10 +40,8 @@ public class NotificationController {
   }
 
   @PutMapping("/{notification-id}/read")
-  public ResponseEntity<Void> updateNotification(@PathVariable("notification-id") Long notificationId) {
-
-    // TODO : 하드코딩 추후 변경
-    Long memberId = 1L;
+  public ResponseEntity<Void> updateNotification(@LoginMemberId Long memberId,
+      @PathVariable("notification-id") Long notificationId) {
 
     notificationService.updateNotification(notificationId, memberId);
 

--- a/src/main/java/com/gogym/post/controller/PostController.java
+++ b/src/main/java/com/gogym/post/controller/PostController.java
@@ -1,12 +1,12 @@
 package com.gogym.post.controller;
 
+import com.gogym.common.annotation.LoginMemberId;
 import com.gogym.post.dto.PostRequestDto;
 import com.gogym.post.dto.PostResponseDto;
 import com.gogym.post.service.PostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,8 +19,8 @@ class PostController {
 
   private final PostService postService;
 
-  @PostMapping("/{member-id}")
-  public ResponseEntity<PostResponseDto> createPost(@PathVariable("member-id") Long memberId,
+  @PostMapping
+  public ResponseEntity<PostResponseDto> createPost(@LoginMemberId Long memberId,
       @RequestBody @Valid PostRequestDto postRequestDto) {
 
     PostResponseDto createdPost = postService.createPost(memberId, postRequestDto);

--- a/src/main/java/com/gogym/post/service/PostService.java
+++ b/src/main/java/com/gogym/post/service/PostService.java
@@ -1,10 +1,7 @@
 package com.gogym.post.service;
 
-import static com.gogym.exception.ErrorCode.MEMBER_NOT_FOUND;
-
-import com.gogym.exception.CustomException;
 import com.gogym.member.entity.Member;
-import com.gogym.member.repository.MemberRepository;
+import com.gogym.member.service.MemberService;
 import com.gogym.post.dto.PostRequestDto;
 import com.gogym.post.dto.PostResponseDto;
 import com.gogym.post.entity.Gym;
@@ -23,7 +20,7 @@ public class PostService {
 
   private final PostRepository postRepository;
 
-  private final MemberRepository memberRepository;
+  private final MemberService memberService;
 
   private final GymRepository gymRepository;
 
@@ -32,8 +29,7 @@ public class PostService {
   @Transactional
   public PostResponseDto createPost(Long memberId, PostRequestDto postRequestDto) {
 
-    // TODO : 추후 MemberService 에서 추출
-    Member member = findByMemberFromMemberRepository(memberId);
+    Member member = memberService.findById(memberId);
 
     Gym gym = findOrCreateGym(postRequestDto);
 
@@ -53,12 +49,5 @@ public class PostService {
     return gymRepository.findByLatitudeAndLongitude(postRequestDto.latitude(),
             postRequestDto.longitude())
         .orElseGet(() -> gymRepository.save(Gym.createGym(postRequestDto, regionId)));
-  }
-
-  // TODO : 추후 MemberService 에서 추출
-  private Member findByMemberFromMemberRepository(Long memberId) {
-
-    return memberRepository.findById(memberId)
-        .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
   }
 }

--- a/src/main/java/com/gogym/region/dto/RegionDto.java
+++ b/src/main/java/com/gogym/region/dto/RegionDto.java
@@ -7,7 +7,8 @@ public record RegionDto(
     Long regionId,
     String name
 ) {
-    public static RegionDto fromEntity(Region region) {
-      return new RegionDto(region.getId(), region.getName());
-    }
+
+  public static RegionDto fromEntity(Region region) {
+    return new RegionDto(region.getId(), region.getName());
+  }
 }

--- a/src/main/java/com/gogym/region/entity/Region.java
+++ b/src/main/java/com/gogym/region/entity/Region.java
@@ -19,12 +19,10 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Table(name = "regions")
-
 // 테스트용 입니다
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-
 public class Region {
 
   @Id

--- a/src/test/java/com/gogym/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/gogym/notification/service/NotificationServiceTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 
 import com.gogym.exception.CustomException;
 import com.gogym.member.entity.Member;
-import com.gogym.member.repository.MemberRepository;
+import com.gogym.member.service.MemberService;
 import com.gogym.notification.dto.NotificationDto;
 import com.gogym.notification.entity.Notification;
 import com.gogym.notification.repository.NotificationRepository;
@@ -40,7 +40,7 @@ class NotificationServiceTest {
   private NotificationRepository notificationRepository;
 
   @Mock
-  private MemberRepository memberRepository;
+  private MemberService memberService;
 
   @Mock
   private SseEmitter sseEmitter;
@@ -70,7 +70,6 @@ class NotificationServiceTest {
   @Test
   void 구독을_신청한_회원은_Map_에_등록되어_관리된다() {
     // given
-    when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
     // when
     sseEmitter = notificationService.subscribe(member.getId());
     // then
@@ -82,7 +81,6 @@ class NotificationServiceTest {
   @Test
   void 알림_생성_시_DB_에_저장된다() {
     // given
-    when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
     // when
     notificationService.createNotification(member.getId(), notificationDto);
     // then
@@ -92,7 +90,6 @@ class NotificationServiceTest {
   @Test
   void 저장된_알림이_있고_읽지_않은_경우_알림이_조회된다() {
     // given
-    when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
     Page<Notification> notificationPage = new PageImpl<>(List.of(notification));
     when(notificationRepository.findAllByMemberIdAndIsReadFalse(member.getId(), pageable)).thenReturn(
         notificationPage);
@@ -108,7 +105,6 @@ class NotificationServiceTest {
   @Test
   void 저장된_알림이_없는_경우_빈_배열을_반환한다() {
     // given
-    when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
     Page<Notification> notificationPage = Page.empty();
 
     when(notificationRepository.findAllByMemberIdAndIsReadFalse(member.getId(), pageable)).thenReturn(
@@ -124,7 +120,6 @@ class NotificationServiceTest {
   @Test
   void 저장된_알림이_있고_읽은_상태면_빈_배열을_반환한다() {
     // given
-    when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
     Page<Notification> notificationPage = new PageImpl<>(List.of(readNotification));
     when(notificationRepository.findAllByMemberIdAndIsReadFalse(member.getId(), pageable)).thenReturn(
         notificationPage);

--- a/src/test/java/com/gogym/post/service/PostServiceTest.java
+++ b/src/test/java/com/gogym/post/service/PostServiceTest.java
@@ -1,24 +1,29 @@
 package com.gogym.post.service;
 
-import static com.gogym.exception.ErrorCode.MEMBER_NOT_FOUND;
+import static com.gogym.post.type.FilterMonthsType.MONTHS_0_3;
+import static com.gogym.post.type.FilterPtType.PT_0_10;
 import static com.gogym.post.type.MembershipType.MEMBERSHIP_ONLY;
+import static com.gogym.post.type.PostStatus.POSTING;
 import static com.gogym.post.type.PostType.SELL;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.gogym.exception.CustomException;
 import com.gogym.member.entity.Member;
 import com.gogym.member.repository.MemberRepository;
+import com.gogym.member.service.MemberService;
+import com.gogym.post.dto.PostFilterRequestDto;
 import com.gogym.post.dto.PostRequestDto;
 import com.gogym.post.entity.Gym;
+import com.gogym.post.entity.Post;
+import com.gogym.post.filter.PostFilterBuilder;
 import com.gogym.post.repository.GymRepository;
 import com.gogym.post.repository.PostRepository;
+import com.gogym.post.repository.PostRepositoryCustom;
 import com.gogym.region.entity.Region;
 import com.gogym.region.service.RegionService;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +31,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 
 @ExtendWith(MockitoExtension.class)
 class PostServiceTest {
@@ -42,6 +52,15 @@ class PostServiceTest {
   @Mock
   private RegionService regionService;
 
+  @Mock
+  private MemberService memberService;
+
+  @Mock
+  private PostFilterBuilder postFilterBuilder;
+
+  @Mock
+  private PostRepositoryCustom postRepositoryCustom;
+
   @InjectMocks
   private PostService postService;
 
@@ -50,12 +69,19 @@ class PostServiceTest {
   private Region parent;
   private Region child;
   private PostRequestDto postRequestDto;
+  private Pageable pageable;
+  private Post post;
+  private List<Long> regionIds;
+  private Page<Post> posts;
+  private PostFilterRequestDto filterRequestDto;
 
   @BeforeEach
   void setUp() {
 
     member = Member.builder()
         .id(1L)
+        .regionId1(1L)
+        .regionId2(2L)
         .build();
     parent = Region.builder()
         .id(1L)
@@ -76,12 +102,24 @@ class PostServiceTest {
         "url1", "url2", "url3",
         "테스트 헬스장", 1.1, 2.2,
         "url", "도시", "지역");
+
+    pageable = PageRequest.of(0, 10, Sort.by(Direction.DESC, "createdAt"));
+
+    post = Post.builder()
+        .title("게시글 제목")
+        .member(member)
+        .gym(gym)
+        .build();
+
+    regionIds = List.of(1L, 2L);
+
+    filterRequestDto = new PostFilterRequestDto(SELL, MEMBERSHIP_ONLY, POSTING, MONTHS_0_3,
+        PT_0_10);
   }
 
   @Test
   void 헬스장이_존재하는_경우_성공적으로_게시글을_작성한다() {
     // given
-    when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
     when(gymRepository.findByLatitudeAndLongitude(postRequestDto.latitude(),
         postRequestDto.longitude())).thenReturn(Optional.of(gym));
     // when
@@ -93,8 +131,6 @@ class PostServiceTest {
   @Test
   void 헬스장이_존재하지_않는_경우_헬스장을_저장한다() {
     // given
-    when(memberRepository.findById(member.getId())).thenReturn(Optional.of(member));
-
     when(gymRepository.findByLatitudeAndLongitude(postRequestDto.latitude(),
         postRequestDto.longitude())).thenReturn(Optional.empty());
     when(gymRepository.save(any(Gym.class))).thenReturn(gym);
@@ -103,17 +139,5 @@ class PostServiceTest {
     // then
     verify(gymRepository).save(any(Gym.class));
     verify(postRepository).save(any());
-  }
-
-  @Test
-  void 회원이_없으면_예외가_발생한다() {
-    // given
-    when(memberRepository.findById(member.getId())).thenReturn(Optional.empty());
-    // when
-    CustomException e = assertThrows(CustomException.class,
-        () -> postService.createPost(member.getId(), postRequestDto));
-    // then
-    assertEquals(e.getMessage(), "회원을 찾을 수 없습니다.");
-    assertEquals(e.getErrorCode(), MEMBER_NOT_FOUND);
   }
 }

--- a/src/test/java/com/gogym/region/service/RegionServiceTest.java
+++ b/src/test/java/com/gogym/region/service/RegionServiceTest.java
@@ -1,4 +1,4 @@
-package com.gogym.post.service;
+package com.gogym.region.service;
 
 import static com.gogym.exception.ErrorCode.CITY_NOT_FOUND;
 import static com.gogym.exception.ErrorCode.DISTRICT_NOT_FOUND;
@@ -11,7 +11,6 @@ import com.gogym.exception.CustomException;
 import com.gogym.region.dto.RegionDto;
 import com.gogym.region.entity.Region;
 import com.gogym.region.repository.RegionRepository;
-import com.gogym.region.service.RegionService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;


### PR DESCRIPTION
## ⚡️ Issue 번호
<!-- 작업한 내용에 해당하는 Issue 번호를 꼭! 기록해주세요 !
키워드: close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved
예시: close #10 !-->
알림, 게시글 회원 가져오기 관련 #45 

## 🛠️ 작업 내용 (What)
- notification, post 패키지 내 회원가져오기 Refactoring
- LoggingAspect Pointcut 추가
- Security API 추가 등록
- 회원이 로그아웃 하는 경우 notification 구독 취소

## 📌 작업 이유 (Why)
- 회원 토큰을 조회하여 회원 ID 값을 특정할 수 있는 로직이 완성되어 리팩토링 합니다.
- schedule 패키지로 Logging 을 남기지 않는것으로 처리하였으나, schedule 레이어 에서 service 레이어를 호출하는 경우 불필요한 Logging 이 남는 현상이 있었습니다.
- 지역관련 API 를 만들었으나, Security 에 추가를 하지 않아 접근이 불가능 했습니다.
- SSE 구독을 해제하기 위해 로그아웃 시 구독 해제 하는 로직이 필요했습니다.

## ✨ 변경 사항 (Changes)
- Controller : @LoginMemberId 어노테이션으로 회원의 토큰을 조회하여 회원 ID 값을 추출합니다.
- Service : 기존 MemberRepository 에서 회원을 조회하는 로직에서 MemberService 로 접근 하여 회원 객체를 반환합니다.
- service 레이어 내에서 불필요한 Log 가 남는 현상이 지속되어 Pointcut 에 제거할 불필요한 메서드를 추가했습니다.
- Region API 를 인증, 인가 없이 접근할수있게 추가 하였습니다.
- 회원이 로그아웃 하는 경우 알림 구독 서비스를 해제합니다.