### PR TITLE
✨️feat : 게시글 조회 및 필터링 구현

### DIFF
--- a/src/main/java/com/gogym/aop/LoginMemberIdHandler.java
+++ b/src/main/java/com/gogym/aop/LoginMemberIdHandler.java
@@ -1,19 +1,19 @@
 package com.gogym.aop;
 
-import com.gogym.member.jwt.JwtTokenProvider;
 import com.gogym.common.annotation.LoginMemberId;
 import com.gogym.exception.CustomException;
 import com.gogym.exception.ErrorCode;
+import com.gogym.member.jwt.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
-
-import jakarta.servlet.http.HttpServletRequest;
 
 // @LoginMemberId 어노테이션을 처리하는 코드
 
@@ -31,8 +31,27 @@ public class LoginMemberIdHandler implements HandlerMethodArgumentResolver {
   @Override
   public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
       NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+
+    LoginMemberId annotation = parameter.getParameterAnnotation(LoginMemberId.class);
+    boolean isRequired = annotation.required();
+
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    if (auth != null && auth.isAuthenticated()) {
+      Object principal = auth.getPrincipal();
+      if (principal instanceof Long) {
+        return principal;
+      }
+    }
+
     HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
     String token = jwtTokenProvider.extractToken(request);
+
+    if (token == null || token.isEmpty()) {
+      if (isRequired) {
+        throw new CustomException(ErrorCode.UNAUTHORIZED);
+      }
+      return null;
+    }
 
     if (!jwtTokenProvider.validateToken(token)) {
       throw new CustomException(ErrorCode.UNAUTHORIZED);
@@ -42,8 +61,10 @@ public class LoginMemberIdHandler implements HandlerMethodArgumentResolver {
     // JWT에서 memberId 추출
     Long memberId = jwtTokenProvider.extractMemberId(token);
     if (memberId == null) {
-      throw new CustomException(ErrorCode.UNAUTHORIZED);
-
+      if (isRequired) {
+        throw new CustomException(ErrorCode.UNAUTHORIZED);
+      }
+      return null;
     }
 
     return memberId;

--- a/src/main/java/com/gogym/common/annotation/LoginMemberId.java
+++ b/src/main/java/com/gogym/common/annotation/LoginMemberId.java
@@ -1,5 +1,6 @@
 package com.gogym.common.annotation;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -9,6 +10,9 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
+@Documented
 public @interface LoginMemberId {
+
+  boolean required() default true;
 
 }

--- a/src/main/java/com/gogym/config/QueryDslConfig.java
+++ b/src/main/java/com/gogym/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.gogym.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+  private final EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/com/gogym/config/SecurityConfig.java
+++ b/src/main/java/com/gogym/config/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
             .requestMatchers("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
                 "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
                 "/api/auth/send-verification-email", "/api/regions", "api/posts",
-                "api/posts/guests/filters", "api/posts/details/*")
+                "api/posts/guests/filters", "api/posts/details/*", "/api/payments/webhook")
             .permitAll()
             // 그 외의 모든 요청은 인증 필요
             .anyRequest().authenticated())
@@ -65,8 +65,7 @@ public class SecurityConfig {
     return List.of("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
         "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
         "/api/auth/send-verification-email", "/api/regions", "api/posts",
-        "api/posts/guests/filters", "api/posts/details/*"
-
+        "api/posts/guests/filters", "api/posts/details/*", "/api/payments/webhook"
     );
   }
 }

--- a/src/main/java/com/gogym/config/SecurityConfig.java
+++ b/src/main/java/com/gogym/config/SecurityConfig.java
@@ -40,13 +40,14 @@ public class SecurityConfig {
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http.csrf().disable().authorizeHttpRequests(auth -> auth
-        // 인증 없이 접근을 허용할 엔드포인트
-        .requestMatchers("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
-            "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
-            "/api/auth/send-verification-email", "/api/regions")
-        .permitAll()
-        // 그 외의 모든 요청은 인증 필요
-        .anyRequest().authenticated())
+            // 인증 없이 접근을 허용할 엔드포인트
+            .requestMatchers("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
+                "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
+                "/api/auth/send-verification-email", "/api/regions", "api/posts",
+                "api/posts/guests/filters", "api/posts/details/*")
+            .permitAll()
+            // 그 외의 모든 요청은 인증 필요
+            .anyRequest().authenticated())
         // JWT 인증 필터를 AuthenticationFilter 전에 추가
         .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
@@ -63,7 +64,8 @@ public class SecurityConfig {
   private List<String> exemptUrls() {
     return List.of("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
         "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
-        "/api/auth/send-verification-email"
+        "/api/auth/send-verification-email", "/api/regions", "api/posts",
+        "api/posts/guests/filters", "api/posts/details/*"
 
     );
   }

--- a/src/main/java/com/gogym/config/SecurityConfig.java
+++ b/src/main/java/com/gogym/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.gogym.config;
 
+import com.gogym.member.jwt.JwtAuthenticationFilter;
+import com.gogym.member.jwt.JwtTokenProvider;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,8 +12,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import com.gogym.member.jwt.JwtAuthenticationFilter;
-import com.gogym.member.jwt.JwtTokenProvider;
 
 @Configuration
 public class SecurityConfig {
@@ -43,8 +43,8 @@ public class SecurityConfig {
             // 인증 없이 접근을 허용할 엔드포인트
             .requestMatchers("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
                 "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
-                "/api/auth/send-verification-email", "/api/regions", "api/posts",
-                "api/posts/guests/filters", "api/posts/details/*", "/api/payments/webhook")
+                "/api/auth/send-verification-email", "/api/regions",
+                "api/posts/views", "api/posts/filters", "api/posts/details/*", "/api/payments/webhook")
             .permitAll()
             // 그 외의 모든 요청은 인증 필요
             .anyRequest().authenticated())
@@ -64,8 +64,8 @@ public class SecurityConfig {
   private List<String> exemptUrls() {
     return List.of("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
         "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
-        "/api/auth/send-verification-email", "/api/regions", "api/posts",
-        "api/posts/guests/filters", "api/posts/details/*", "/api/payments/webhook"
+        "/api/auth/send-verification-email", "/api/regions",
+        "api/posts/views", "api/posts/filters", "api/posts/details/*", "/api/payments/webhook"
     );
   }
 }

--- a/src/main/java/com/gogym/exception/ErrorCode.java
+++ b/src/main/java/com/gogym/exception/ErrorCode.java
@@ -30,6 +30,8 @@ public enum ErrorCode {
   CHAT_MESSAGE_NOT_FOUND(NOT_FOUND, "채팅 메시지를 찾을 수 없습니다."),
   CITY_NOT_FOUND(NOT_FOUND, "도시를 찾을 수 없습니다."),
   DISTRICT_NOT_FOUND(NOT_FOUND, "지역을 찾을 수 없습니다."),
+  POST_NOT_FOUND(NOT_FOUND, "게시글을 찾을 수 없습니다."),
+  DELETED_POST(NOT_FOUND, "삭제된 게시글입니다."),
   GYM_PAY_NOT_FOUND(NOT_FOUND, "짐페이를 찾을 수 없습니다. 짐페이를 개설해주세요."),
   PAYMENT_NOT_FOUND(NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
 

--- a/src/main/java/com/gogym/exception/ErrorCode.java
+++ b/src/main/java/com/gogym/exception/ErrorCode.java
@@ -34,19 +34,21 @@ public enum ErrorCode {
   DELETED_POST(NOT_FOUND, "삭제된 게시글입니다."),
   GYM_PAY_NOT_FOUND(NOT_FOUND, "짐페이를 찾을 수 없습니다. 짐페이를 개설해주세요."),
   PAYMENT_NOT_FOUND(NOT_FOUND, "결제 정보를 찾을 수 없습니다."),
+  SSE_SUBSCRIPTION_NOT_FOUND(NOT_FOUND, "요청한 구독 정보가 존재하지 않습니다."),
 
   // 409 CONFLICT
   DUPLICATE_EMAIL(CONFLICT, "이미 사용 중인 이메일입니다."),
   DUPLICATE_NICKNAME(CONFLICT, "이미 사용 중인 닉네임입니다."),
   ALREADY_READ(CONFLICT, "이미 확인한 알림입니다."),
   CHATROOM_ALREADY_EXISTS(CONFLICT, "이미 존재하는 채팅방입니다."),
+  PAYMENT_MISMATCH(CONFLICT, "결제 정보가 일치하지 않습니다."),
 
   // 500 INTERNAL SERVER ERROR
   JSON_MAPPING_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "JSON 변환 중 오류가 발생했습니다."),
   PORTONE_API_CALL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "포트원 API 호출 중 오류가 발생했습니다."),
+  SSE_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SSE 전송 중 오류가 발생했습니다."),
   INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다.");
 
   private final HttpStatus httpStatus;
   private final String message;
 }
-

--- a/src/main/java/com/gogym/notification/entity/Notification.java
+++ b/src/main/java/com/gogym/notification/entity/Notification.java
@@ -43,6 +43,6 @@ public class Notification extends BaseEntity {
   }
 
   public void read() {
-    this.isRead = true;
+    isRead = true;
   }
 }

--- a/src/main/java/com/gogym/post/controller/PostController.java
+++ b/src/main/java/com/gogym/post/controller/PostController.java
@@ -1,15 +1,27 @@
 package com.gogym.post.controller;
 
 import com.gogym.common.annotation.LoginMemberId;
+import com.gogym.post.dto.PostFilterRequestDto;
+import com.gogym.post.dto.PostPageResponseDto;
 import com.gogym.post.dto.PostRequestDto;
 import com.gogym.post.dto.PostResponseDto;
 import com.gogym.post.service.PostService;
+import com.gogym.post.type.FilterMonthsType;
+import com.gogym.post.type.FilterPtType;
+import com.gogym.post.type.MembershipType;
+import com.gogym.post.type.PostStatus;
+import com.gogym.post.type.PostType;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,5 +38,73 @@ class PostController {
     PostResponseDto createdPost = postService.createPost(memberId, postRequestDto);
 
     return ResponseEntity.ok(createdPost);
+  }
+
+  // 비회원의 게시글 목록 조회 입니다.
+  @GetMapping
+  public ResponseEntity<Page<PostPageResponseDto>> getAllPosts(Pageable pageable) {
+
+    Page<PostPageResponseDto> page = postService.getAllPostsOfGuest(pageable);
+
+    return ResponseEntity.ok(page);
+  }
+
+  // 회원의 게시글 목록 조회 입니다.
+  @GetMapping("/members")
+  public ResponseEntity<Page<PostPageResponseDto>> getAllPostsOfMember(
+      @LoginMemberId Long memberId, Pageable pageable) {
+
+    Page<PostPageResponseDto> page = postService.getAllPostsOfMember(memberId, pageable);
+
+    return ResponseEntity.ok(page);
+  }
+
+  // 비회원의 필터링 된 게시글 목록 조회 입니다. 쿼리 파라미터로 값을 받습니다.
+  @GetMapping("/guests/filters")
+  public ResponseEntity<Page<PostPageResponseDto>> getFilterPostsOfGuest(
+      @RequestParam(value = "post-type", required = false) PostType postType,
+      @RequestParam(value = "membership-type", required = false) MembershipType membershipType,
+      @RequestParam(value = "status", required = false) PostStatus status,
+      @RequestParam(value = "months-type", required = false) FilterMonthsType monthsType,
+      @RequestParam(value = "pt-type", required = false) FilterPtType ptType
+      , Pageable pageable) {
+
+    PostFilterRequestDto postFilterRequestDto = new PostFilterRequestDto(postType, membershipType,
+        status, monthsType, ptType);
+
+    Page<PostPageResponseDto> page = postService.getFilterPostsOfGuest(postFilterRequestDto,
+        pageable);
+
+    return ResponseEntity.ok(page);
+  }
+
+  // 회원의 필터링 된 게시글 목록 조회 입니다. 쿼리 파라미터로 값을 받습니다.
+  @GetMapping("/members/filters")
+  public ResponseEntity<Page<PostPageResponseDto>> getFilterPostsOfMember(
+      @LoginMemberId Long memberId,
+      @RequestParam(value = "post-type", required = false) PostType postType,
+      @RequestParam(value = "membership-type", required = false) MembershipType membershipType,
+      @RequestParam(value = "status", required = false) PostStatus status,
+      @RequestParam(value = "months-type", required = false) FilterMonthsType monthsType,
+      @RequestParam(value = "pt-type", required = false) FilterPtType ptType
+      , Pageable pageable) {
+
+    PostFilterRequestDto postFilterRequestDto = new PostFilterRequestDto(postType, membershipType,
+        status, monthsType, ptType);
+
+    Page<PostPageResponseDto> page = postService.getFilterPostsOfMember(memberId,
+        postFilterRequestDto,
+        pageable);
+
+    return ResponseEntity.ok(page);
+  }
+
+  // 게시글 상세 조회 입니다.
+  @GetMapping("/details/{post-id}")
+  public ResponseEntity<PostResponseDto> getDetailPost(@PathVariable("post-id") Long postId) {
+
+    PostResponseDto postResponseDto = postService.getDetailPost(postId);
+
+    return ResponseEntity.ok(postResponseDto);
   }
 }

--- a/src/main/java/com/gogym/post/controller/PostController.java
+++ b/src/main/java/com/gogym/post/controller/PostController.java
@@ -40,48 +40,19 @@ class PostController {
     return ResponseEntity.ok(createdPost);
   }
 
-  // 비회원의 게시글 목록 조회 입니다.
-  @GetMapping
-  public ResponseEntity<Page<PostPageResponseDto>> getAllPosts(Pageable pageable) {
-
-    Page<PostPageResponseDto> page = postService.getAllPosts(null, pageable);
-
-    return ResponseEntity.ok(page);
-  }
-
-  // 회원의 게시글 목록 조회 입니다.
-  @GetMapping("/members")
+  // 토큰이 존재하면 회원, 존재하지 않으면 비회원의 게시글 목록 조회 입니다.
+  @GetMapping("/views")
   public ResponseEntity<Page<PostPageResponseDto>> getAllPostsOfMember(
-      @LoginMemberId Long memberId, Pageable pageable) {
-
+      @LoginMemberId(required = false) Long memberId, Pageable pageable) {
     Page<PostPageResponseDto> page = postService.getAllPosts(memberId, pageable);
 
     return ResponseEntity.ok(page);
   }
 
-  // 비회원의 필터링 된 게시글 목록 조회 입니다. 쿼리 파라미터로 값을 받습니다.
-  @GetMapping("/guests/filters")
-  public ResponseEntity<Page<PostPageResponseDto>> getFilterPostsOfGuest(
-      @RequestParam(value = "post-type", required = false) PostType postType,
-      @RequestParam(value = "membership-type", required = false) MembershipType membershipType,
-      @RequestParam(value = "status", required = false) PostStatus status,
-      @RequestParam(value = "months-type", required = false) FilterMonthsType monthsType,
-      @RequestParam(value = "pt-type", required = false) FilterPtType ptType
-      , Pageable pageable) {
-
-    PostFilterRequestDto postFilterRequestDto = new PostFilterRequestDto(postType, membershipType,
-        status, monthsType, ptType);
-
-    Page<PostPageResponseDto> page = postService.getFilterPosts(null, postFilterRequestDto,
-        pageable);
-
-    return ResponseEntity.ok(page);
-  }
-
-  // 회원의 필터링 된 게시글 목록 조회 입니다. 쿼리 파라미터로 값을 받습니다.
-  @GetMapping("/members/filters")
+  // 토큰이 존재하면 회원, 존재하지 않으면 비회원의 필터링 된 게시글 목록 조회 입니다. 쿼리 파라미터로 값을 받습니다.
+  @GetMapping("/filters")
   public ResponseEntity<Page<PostPageResponseDto>> getFilterPostsOfMember(
-      @LoginMemberId Long memberId,
+      @LoginMemberId(required = false) Long memberId,
       @RequestParam(value = "post-type", required = false) PostType postType,
       @RequestParam(value = "membership-type", required = false) MembershipType membershipType,
       @RequestParam(value = "status", required = false) PostStatus status,

--- a/src/main/java/com/gogym/post/controller/PostController.java
+++ b/src/main/java/com/gogym/post/controller/PostController.java
@@ -44,7 +44,7 @@ class PostController {
   @GetMapping
   public ResponseEntity<Page<PostPageResponseDto>> getAllPosts(Pageable pageable) {
 
-    Page<PostPageResponseDto> page = postService.getAllPostsOfGuest(pageable);
+    Page<PostPageResponseDto> page = postService.getAllPosts(null, pageable);
 
     return ResponseEntity.ok(page);
   }
@@ -54,7 +54,7 @@ class PostController {
   public ResponseEntity<Page<PostPageResponseDto>> getAllPostsOfMember(
       @LoginMemberId Long memberId, Pageable pageable) {
 
-    Page<PostPageResponseDto> page = postService.getAllPostsOfMember(memberId, pageable);
+    Page<PostPageResponseDto> page = postService.getAllPosts(memberId, pageable);
 
     return ResponseEntity.ok(page);
   }
@@ -72,7 +72,7 @@ class PostController {
     PostFilterRequestDto postFilterRequestDto = new PostFilterRequestDto(postType, membershipType,
         status, monthsType, ptType);
 
-    Page<PostPageResponseDto> page = postService.getFilterPostsOfGuest(postFilterRequestDto,
+    Page<PostPageResponseDto> page = postService.getFilterPosts(null, postFilterRequestDto,
         pageable);
 
     return ResponseEntity.ok(page);
@@ -92,7 +92,7 @@ class PostController {
     PostFilterRequestDto postFilterRequestDto = new PostFilterRequestDto(postType, membershipType,
         status, monthsType, ptType);
 
-    Page<PostPageResponseDto> page = postService.getFilterPostsOfMember(memberId,
+    Page<PostPageResponseDto> page = postService.getFilterPosts(memberId,
         postFilterRequestDto,
         pageable);
 

--- a/src/main/java/com/gogym/post/dto/PostFilterRequestDto.java
+++ b/src/main/java/com/gogym/post/dto/PostFilterRequestDto.java
@@ -1,0 +1,17 @@
+package com.gogym.post.dto;
+
+import com.gogym.post.type.FilterMonthsType;
+import com.gogym.post.type.FilterPtType;
+import com.gogym.post.type.MembershipType;
+import com.gogym.post.type.PostStatus;
+import com.gogym.post.type.PostType;
+
+public record PostFilterRequestDto(
+
+    PostType postType,
+    MembershipType membershipType,
+    PostStatus status,
+    FilterMonthsType monthsType,
+    FilterPtType ptType
+
+) {}

--- a/src/main/java/com/gogym/post/dto/PostPageResponseDto.java
+++ b/src/main/java/com/gogym/post/dto/PostPageResponseDto.java
@@ -1,0 +1,41 @@
+package com.gogym.post.dto;
+
+import com.gogym.post.entity.Post;
+import com.gogym.post.type.PostStatus;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record PostPageResponseDto(
+
+    Long postId,
+    String title,
+    PostStatus postStatus,
+    Long amount,
+    String imageUrl1,
+    String imageUrl2,
+    String imageUrl3,
+    String gymName,
+    LocalDateTime createdAt,
+    Long wishCount,
+    String authorNickname
+
+) {
+
+  public static PostPageResponseDto fromEntity(Post post) {
+
+    return PostPageResponseDto.builder()
+        .postId(post.getId())
+        .title(post.getTitle())
+        .postStatus(post.getStatus())
+        .amount(post.getAmount())
+        .imageUrl1(post.getImageUrl1())
+        .imageUrl2(post.getImageUrl2())
+        .imageUrl3(post.getImageUrl3())
+        .gymName(post.getGym().getGymName())
+        .createdAt(post.getCreatedAt())
+        .wishCount(post.getWishCount())
+        .authorNickname(post.getMember().getNickname())
+        .build();
+  }
+}

--- a/src/main/java/com/gogym/post/dto/PostPageResponseDto.java
+++ b/src/main/java/com/gogym/post/dto/PostPageResponseDto.java
@@ -10,7 +10,7 @@ public record PostPageResponseDto(
 
     Long postId,
     String title,
-    PostStatus postStatus,
+    PostStatus status,
     Long amount,
     String imageUrl1,
     String imageUrl2,
@@ -27,7 +27,7 @@ public record PostPageResponseDto(
     return PostPageResponseDto.builder()
         .postId(post.getId())
         .title(post.getTitle())
-        .postStatus(post.getStatus())
+        .status(post.getStatus())
         .amount(post.getAmount())
         .imageUrl1(post.getImageUrl1())
         .imageUrl2(post.getImageUrl2())

--- a/src/main/java/com/gogym/post/dto/PostResponseDto.java
+++ b/src/main/java/com/gogym/post/dto/PostResponseDto.java
@@ -4,12 +4,16 @@ import com.gogym.post.entity.Post;
 import com.gogym.post.type.MembershipType;
 import com.gogym.post.type.PostStatus;
 import com.gogym.post.type.PostType;
+import com.gogym.region.dto.RegionResponseDto;
 import java.time.LocalDate;
 import lombok.Builder;
 
 @Builder
 public record PostResponseDto(
 
+    Long postId,
+    Long memberId,
+    String memberNickname,
     String title,
     String content,
     PostType postType,
@@ -18,18 +22,24 @@ public record PostResponseDto(
     String imageUrl1,
     String imageUrl2,
     String imageUrl3,
-    String gymName,
     Long wishCount,
     MembershipType membershipType,
     LocalDate expirationDate,
     Long remainingSessions,
-    String gymKakaoUrl
+    Long gymId,
+    String gymName,
+    String gymKakaoUrl,
+    String city,
+    String district
 
 ) {
 
-  public static PostResponseDto fromEntity(Post post) {
+  public static PostResponseDto fromEntity(Post post, RegionResponseDto regionResponseDto) {
 
     return PostResponseDto.builder()
+        .postId(post.getId())
+        .memberId(post.getMember().getId())
+        .memberNickname(post.getMember().getNickname())
         .title(post.getTitle())
         .content(post.getContent())
         .postType(post.getPostType())
@@ -38,12 +48,15 @@ public record PostResponseDto(
         .imageUrl1(post.getImageUrl1())
         .imageUrl2(post.getImageUrl2())
         .imageUrl3(post.getImageUrl3())
-        .gymName(post.getGym().getGymName())
         .wishCount(post.getWishCount())
         .membershipType(post.getMembershipType())
         .expirationDate(post.getExpirationDate())
         .remainingSessions(post.getRemainingSessions())
+        .gymId(post.getGym().getId())
+        .gymName(post.getGym().getGymName())
         .gymKakaoUrl(post.getGym().getGymKakaoUrl())
+        .city(regionResponseDto.city())
+        .district(regionResponseDto.district())
         .build();
   }
 }

--- a/src/main/java/com/gogym/post/entity/Post.java
+++ b/src/main/java/com/gogym/post/entity/Post.java
@@ -46,6 +46,7 @@ public class Post extends BaseEntity {
   private String content;
 
   @Column(name = "post_type", nullable = false)
+  @Enumerated(EnumType.STRING)
   private PostType postType;
 
   @Column(nullable = false)

--- a/src/main/java/com/gogym/post/filter/PostFilterBuilder.java
+++ b/src/main/java/com/gogym/post/filter/PostFilterBuilder.java
@@ -1,0 +1,91 @@
+package com.gogym.post.filter;
+
+import com.gogym.post.dto.PostFilterRequestDto;
+import com.gogym.post.entity.QPost;
+import com.gogym.post.type.FilterMonthsType;
+import com.gogym.post.type.FilterPtType;
+import com.gogym.post.type.MembershipType;
+import com.gogym.post.type.PostStatus;
+import com.gogym.post.type.PostType;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostFilterBuilder {
+
+  public BooleanBuilder builderFilters(List<Long> regionIds,
+      PostFilterRequestDto postFilterRequestDto) {
+
+    BooleanBuilder builder = new BooleanBuilder();
+    QPost post = QPost.post;
+
+    builder.and(applyStatusFilter(postFilterRequestDto.status(), post));
+    builder.and(applyPostTypeFilter(postFilterRequestDto.postType(), post));
+    builder.and(applyMembershipTypeFilter(postFilterRequestDto.membershipType(), post));
+    builder.and(applyMonthsTypeFilter(postFilterRequestDto.monthsType(), post));
+    builder.and(applyPtTypeFilter(postFilterRequestDto.ptType(), post));
+    builder.and(applyRegionFilter(regionIds, post));
+
+    return builder;
+  }
+
+  // 게시글 상태 필터
+  private Predicate applyStatusFilter(PostStatus status, QPost post) {
+
+    return status != null ? new BooleanBuilder(post.status.eq(status)) : new BooleanBuilder();
+  }
+
+  // 게시글 타입 필터
+  private Predicate applyPostTypeFilter(PostType postType, QPost post) {
+
+    return postType != null ? new BooleanBuilder(post.postType.eq(postType)) : new BooleanBuilder();
+  }
+
+  // 멤버쉽 타입 필터
+  private Predicate applyMembershipTypeFilter(MembershipType membershipType, QPost post) {
+
+    return membershipType != null ? new BooleanBuilder(post.membershipType.eq(membershipType))
+        : new BooleanBuilder();
+  }
+
+  // 남은 기간 필터
+  private Predicate applyMonthsTypeFilter(FilterMonthsType monthsType, QPost post) {
+
+    if (monthsType == null) {
+      return new BooleanBuilder();
+    }
+
+    LocalDate now = LocalDate.now();
+
+    return switch (monthsType) {
+      case MONTHS_0_3 -> new BooleanBuilder(post.expirationDate.before(now.plusMonths(3)));
+      case MONTHS_3_6 -> new BooleanBuilder(post.expirationDate.between(now.plusMonths(3),
+          LocalDate.now().plusMonths(6)));
+      case MONTHS_6_PLUS -> new BooleanBuilder(post.expirationDate.after(now.plusMonths(6)));
+    };
+  }
+
+  // 남은 PT 횟수 필터
+  private Predicate applyPtTypeFilter(FilterPtType ptType, QPost post) {
+
+    if (ptType == null) {
+      return new BooleanBuilder();
+    }
+
+    return switch (ptType) {
+      case PT_0_10 -> new BooleanBuilder((post.remainingSessions.loe(10L)));
+      case PT_10_25 -> new BooleanBuilder(post.remainingSessions.between(10L, 25L));
+      case PT_25_PLUS -> new BooleanBuilder(post.remainingSessions.goe(25L));
+    };
+  }
+
+  // 관심지역 필터
+  private Predicate applyRegionFilter(List<Long> regionIds, QPost post) {
+
+    return regionIds != null && !regionIds.isEmpty() ? new BooleanBuilder(
+        post.gym.regionId.in(regionIds)) : new BooleanBuilder();
+  }
+}

--- a/src/main/java/com/gogym/post/repository/PostRepository.java
+++ b/src/main/java/com/gogym/post/repository/PostRepository.java
@@ -1,7 +1,19 @@
 package com.gogym.post.repository;
 
 import com.gogym.post.entity.Post;
+import com.gogym.post.type.PostStatus;
+import io.lettuce.core.dynamic.annotation.Param;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
+
+  Page<Post> findAllByStatus(Pageable pageable, PostStatus postStatus);
+
+  @Query("SELECT p FROM Post p WHERE p.status = :status AND p.gym.regionId IN :regionIds")
+  Page<Post> findAllByStatusAndRegionIds(@Param("status") PostStatus status,
+      Pageable sortedByDate, @Param("regionIds") List<Long> regionIds);
 }

--- a/src/main/java/com/gogym/post/repository/PostRepository.java
+++ b/src/main/java/com/gogym/post/repository/PostRepository.java
@@ -16,4 +16,6 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
   @Query("SELECT p FROM Post p WHERE p.status = :status AND p.gym.regionId IN :regionIds")
   Page<Post> findAllByStatusAndRegionIds(@Param("status") PostStatus status,
       Pageable sortedByDate, @Param("regionIds") List<Long> regionIds);
+
+  Page<Post> findByMemberIdOrderByCreatedAtDesc(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/gogym/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/gogym/post/repository/PostRepositoryCustom.java
@@ -1,11 +1,12 @@
 package com.gogym.post.repository;
 
+import com.gogym.post.dto.PostFilterRequestDto;
 import com.gogym.post.entity.Post;
-import com.querydsl.core.BooleanBuilder;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface PostRepositoryCustom {
 
-  Page<Post> findAllWithFilter(BooleanBuilder filter, Pageable sortedByDate);
+  Page<Post> findAllWithFilter(List<Long> regionIds, PostFilterRequestDto postFilterRequestDto, Pageable sortedByDate);
 }

--- a/src/main/java/com/gogym/post/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/gogym/post/repository/PostRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.gogym.post.repository;
+
+import com.gogym.post.entity.Post;
+import com.querydsl.core.BooleanBuilder;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostRepositoryCustom {
+
+  Page<Post> findAllWithFilter(BooleanBuilder filter, Pageable sortedByDate);
+}

--- a/src/main/java/com/gogym/post/repository/impl/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/gogym/post/repository/impl/PostRepositoryCustomImpl.java
@@ -1,7 +1,9 @@
 package com.gogym.post.repository.impl;
 
+import com.gogym.post.dto.PostFilterRequestDto;
 import com.gogym.post.entity.Post;
 import com.gogym.post.entity.QPost;
+import com.gogym.post.filter.PostFilterBuilder;
 import com.gogym.post.repository.PostRepositoryCustom;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -21,10 +23,16 @@ public class PostRepositoryCustomImpl implements PostRepositoryCustom {
 
   private final JPAQueryFactory queryFactory;
 
+  private final PostFilterBuilder postFilterBuilder;
+
   @Override
-  public Page<Post> findAllWithFilter(BooleanBuilder filter, Pageable sortedByDate) {
+  public Page<Post> findAllWithFilter(List<Long> regionIds,
+      PostFilterRequestDto postFilterRequestDto, Pageable sortedByDate) {
 
     QPost post = QPost.post;
+
+    BooleanBuilder filter = postFilterBuilder.builderFilters(regionIds, postFilterRequestDto);
+
     List<Post> posts = queryFactory.selectFrom(post)
         .where(filter)
         .offset(sortedByDate.getOffset())

--- a/src/main/java/com/gogym/post/repository/impl/PostRepositoryCustomImpl.java
+++ b/src/main/java/com/gogym/post/repository/impl/PostRepositoryCustomImpl.java
@@ -1,0 +1,43 @@
+package com.gogym.post.repository.impl;
+
+import com.gogym.post.entity.Post;
+import com.gogym.post.entity.QPost;
+import com.gogym.post.repository.PostRepositoryCustom;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+@Primary
+public class PostRepositoryCustomImpl implements PostRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<Post> findAllWithFilter(BooleanBuilder filter, Pageable sortedByDate) {
+
+    QPost post = QPost.post;
+    List<Post> posts = queryFactory.selectFrom(post)
+        .where(filter)
+        .offset(sortedByDate.getOffset())
+        .limit(sortedByDate.getPageSize())
+        .orderBy(post.createdAt.desc())
+        .fetch();
+
+    Long total = Optional.ofNullable(queryFactory.select(post.count())
+            .from(post)
+            .where(filter)
+            .fetchFirst())
+        .orElse(0L);
+
+    return new PageImpl<>(posts, sortedByDate, total);
+  }
+}

--- a/src/main/java/com/gogym/post/service/GymService.java
+++ b/src/main/java/com/gogym/post/service/GymService.java
@@ -1,0 +1,28 @@
+package com.gogym.post.service;
+
+import com.gogym.post.dto.PostRequestDto;
+import com.gogym.post.entity.Gym;
+import com.gogym.post.repository.GymRepository;
+import com.gogym.region.service.RegionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GymService {
+
+  private final GymRepository gymRepository;
+
+  private final RegionService regionService;
+
+  public Gym findOrCreateGym(PostRequestDto postRequestDto) {
+
+    Long regionId = regionService.getChildRegionId(postRequestDto.city(),
+        postRequestDto.district());
+
+    // 위도와 경도 기준으로 저장된 헬스장이 있는지 확인 후 없으면 새로 생성합니다.
+    return gymRepository.findByLatitudeAndLongitude(postRequestDto.latitude(),
+            postRequestDto.longitude())
+        .orElseGet(() -> gymRepository.save(Gym.createGym(postRequestDto, regionId)));
+  }
+}

--- a/src/main/java/com/gogym/post/service/PostService.java
+++ b/src/main/java/com/gogym/post/service/PostService.java
@@ -9,7 +9,6 @@ import static com.gogym.post.type.PostStatus.POSTING;
 import com.gogym.exception.CustomException;
 import com.gogym.member.entity.Member;
 import com.gogym.member.service.MemberService;
-import com.gogym.notification.service.NotificationService;
 import com.gogym.post.dto.PostFilterRequestDto;
 import com.gogym.post.dto.PostPageResponseDto;
 import com.gogym.post.dto.PostRequestDto;
@@ -20,7 +19,6 @@ import com.gogym.post.filter.PostFilterBuilder;
 import com.gogym.post.repository.GymRepository;
 import com.gogym.post.repository.PostRepository;
 import com.gogym.post.repository.PostRepositoryCustom;
-import com.gogym.post.repository.WishRepository;
 import com.gogym.region.dto.RegionResponseDto;
 import com.gogym.region.service.RegionService;
 import com.querydsl.core.BooleanBuilder;
@@ -50,10 +48,6 @@ public class PostService {
   private final PostFilterBuilder postFilterBuilder;
 
   private final PostRepositoryCustom postRepositoryCustom;
-
-  private final WishRepository wishRepository;
-
-  private final NotificationService notificationService;
 
   @Transactional
   public PostResponseDto createPost(Long memberId, PostRequestDto postRequestDto) {

--- a/src/main/java/com/gogym/post/service/PostService.java
+++ b/src/main/java/com/gogym/post/service/PostService.java
@@ -1,15 +1,36 @@
 package com.gogym.post.service;
 
+import static com.gogym.exception.ErrorCode.DELETED_POST;
+import static com.gogym.exception.ErrorCode.MEMBER_NOT_FOUND;
+import static com.gogym.exception.ErrorCode.POST_NOT_FOUND;
+import static com.gogym.post.type.PostStatus.HIDDEN;
+import static com.gogym.post.type.PostStatus.POSTING;
+
+import com.gogym.exception.CustomException;
 import com.gogym.member.entity.Member;
 import com.gogym.member.service.MemberService;
+import com.gogym.notification.service.NotificationService;
+import com.gogym.post.dto.PostFilterRequestDto;
+import com.gogym.post.dto.PostPageResponseDto;
 import com.gogym.post.dto.PostRequestDto;
 import com.gogym.post.dto.PostResponseDto;
 import com.gogym.post.entity.Gym;
 import com.gogym.post.entity.Post;
+import com.gogym.post.filter.PostFilterBuilder;
 import com.gogym.post.repository.GymRepository;
 import com.gogym.post.repository.PostRepository;
+import com.gogym.post.repository.PostRepositoryCustom;
+import com.gogym.post.repository.WishRepository;
+import com.gogym.region.dto.RegionResponseDto;
 import com.gogym.region.service.RegionService;
+import com.querydsl.core.BooleanBuilder;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +47,14 @@ public class PostService {
 
   private final RegionService regionService;
 
+  private final PostFilterBuilder postFilterBuilder;
+
+  private final PostRepositoryCustom postRepositoryCustom;
+
+  private final WishRepository wishRepository;
+
+  private final NotificationService notificationService;
+
   @Transactional
   public PostResponseDto createPost(Long memberId, PostRequestDto postRequestDto) {
 
@@ -37,7 +66,9 @@ public class PostService {
 
     postRepository.save(post);
 
-    return PostResponseDto.fromEntity(post);
+    RegionResponseDto regionResponseDto = regionService.findById(post.getGym().getRegionId());
+
+    return PostResponseDto.fromEntity(post, regionResponseDto);
   }
 
   private Gym findOrCreateGym(PostRequestDto postRequestDto) {
@@ -49,5 +80,118 @@ public class PostService {
     return gymRepository.findByLatitudeAndLongitude(postRequestDto.latitude(),
             postRequestDto.longitude())
         .orElseGet(() -> gymRepository.save(Gym.createGym(postRequestDto, regionId)));
+  }
+
+  // 로그인 하지 않은 일반 회원이 게시글 목록을 보는 상황입니다.
+  public Page<PostPageResponseDto> getAllPostsOfGuest(Pageable pageable) {
+
+    return fetchPosts(null, pageable);
+  }
+
+  // 로그인 된 회원이 게시글 목록을 보는 상황입니다.
+  public Page<PostPageResponseDto> getAllPostsOfMember(Long memberId, Pageable pageable) {
+
+    List<Long> regionIds = getRegionIds(memberId);
+
+    return fetchPosts(regionIds, pageable);
+  }
+
+  // 회원과 비회원의 기준으로 보여주는 게시글을 찾습니다. 회원의 경우 설정된 관심지역을 기준으로 보여집니다.
+  private Page<PostPageResponseDto> fetchPosts(List<Long> regionIds, Pageable pageable) {
+
+    Pageable sortedByDate = getSortPageable(pageable);
+
+    Page<Post> posts = regionIds == null
+        ? postRepository.findAllByStatus(sortedByDate, POSTING)
+        : postRepository.findAllByStatusAndRegionIds(POSTING, sortedByDate, regionIds);
+
+    return posts != null ? posts.map(PostPageResponseDto::fromEntity) : Page.empty();
+  }
+
+  // 비회원이 게시글을 필터링 하는 경우
+  public Page<PostPageResponseDto> getFilterPostsOfGuest(PostFilterRequestDto postFilterRequestDto,
+      Pageable pageable) {
+    return fetchFilterPosts(null, postFilterRequestDto, pageable);
+  }
+
+  // 회원이 게시글을 필터링 하는 경우
+  public Page<PostPageResponseDto> getFilterPostsOfMember(Long memberId,
+      PostFilterRequestDto postFilterRequestDto, Pageable pageable) {
+
+    List<Long> regionIds = getRegionIds(memberId);
+
+    return fetchFilterPosts(regionIds, postFilterRequestDto, pageable);
+  }
+
+  // 필터링 적용 메서드 입니다.
+  private Page<PostPageResponseDto> fetchFilterPosts(List<Long> regionIds,
+      PostFilterRequestDto postFilterRequestDto,
+      Pageable pageable) {
+
+    Pageable sortedByDate = getSortPageable(pageable);
+
+    // 필터 설정
+    BooleanBuilder filter = postFilterBuilder.builderFilters(regionIds, postFilterRequestDto);
+
+    Page<Post> filteredPosts = postRepositoryCustom.findAllWithFilter(filter, sortedByDate);
+
+    return filteredPosts != null ? filteredPosts.map(PostPageResponseDto::fromEntity)
+        : Page.empty();
+  }
+
+  // 게시글의 상세 페이지를 조회합니다.
+  public PostResponseDto getDetailPost(Long postId) {
+
+    Post post = findById(postId);
+
+    // 숨김처리(삭제) 된 게시글은 조회가 불가능합니다.
+    if (post.getStatus() == HIDDEN) {
+      throw new CustomException(DELETED_POST);
+    }
+
+    RegionResponseDto regionResponseDto = regionService.findById(post.getGym().getRegionId());
+
+    return PostResponseDto.fromEntity(post, regionResponseDto);
+  }
+
+  // 회원의 경우 설정된 관심지역을 가져옵니다.
+  private List<Long> getRegionIds(Long memberId) {
+
+    Member member = memberService.findById(memberId);
+
+    // 회원의 지역을 추출
+    Long regionId1 = member.getRegionId1();
+    Long regionId2 = member.getRegionId2();
+
+    // 관심지역을 설정하지 않은 경우 모든 목록 반환
+    if (regionId1 == null && regionId2 == null) {
+      return null;
+    }
+
+    // 관심지역 1과 2 중 둘중 하나만 설정되었거나, 둘다 설정된 경우 값 반환
+    return regionId1 == null ? List.of(regionId2)
+        : regionId2 == null ? List.of(regionId1) : List.of(regionId1, regionId2);
+  }
+
+  // 게시글이 생성된 시간(날짜) 기준으로 역정렬 합니다.
+  private Pageable getSortPageable(Pageable pageable) {
+    return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+        Sort.by(Direction.DESC, "createdAt"));
+  }
+
+  // 주어진 게시글 ID 로 게시글을 찾습니다.
+  public Post findById(Long postId) {
+
+    return postRepository.findById(postId).orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+  }
+
+  // 채팅방 에서 호출할 메서드입니다. 게시글 작성자를 찾습니다.
+  public Member getPostAuthor(Long postId) {
+
+    if (findById(postId).getMember() == null) {
+      throw new CustomException(MEMBER_NOT_FOUND);
+    } else {
+      return findById(postId).getMember();
+    }
   }
 }

--- a/src/main/java/com/gogym/post/type/FilterMonthsType.java
+++ b/src/main/java/com/gogym/post/type/FilterMonthsType.java
@@ -1,0 +1,6 @@
+package com.gogym.post.type;
+
+public enum FilterMonthsType {
+  // 3개월 이하, 3-6개월, 6개월 이상
+  MONTHS_0_3, MONTHS_3_6, MONTHS_6_PLUS
+}

--- a/src/main/java/com/gogym/post/type/FilterPtType.java
+++ b/src/main/java/com/gogym/post/type/FilterPtType.java
@@ -1,0 +1,6 @@
+package com.gogym.post.type;
+
+public enum FilterPtType {
+  // 10회 이하, 10-25회, 25회 이상
+  PT_0_10, PT_10_25, PT_25_PLUS
+}

--- a/src/main/java/com/gogym/region/dto/RegionResponseDto.java
+++ b/src/main/java/com/gogym/region/dto/RegionResponseDto.java
@@ -1,0 +1,7 @@
+package com.gogym.region.dto;
+
+public record RegionResponseDto(
+
+    String city,
+    String district
+) {}

--- a/src/main/java/com/gogym/region/service/RegionService.java
+++ b/src/main/java/com/gogym/region/service/RegionService.java
@@ -5,6 +5,7 @@ import static com.gogym.exception.ErrorCode.DISTRICT_NOT_FOUND;
 
 import com.gogym.exception.CustomException;
 import com.gogym.region.dto.RegionDto;
+import com.gogym.region.dto.RegionResponseDto;
 import com.gogym.region.entity.Region;
 import com.gogym.region.repository.RegionRepository;
 import java.util.List;
@@ -38,5 +39,14 @@ public class RegionService {
         .orElseThrow(() -> new CustomException(DISTRICT_NOT_FOUND));
 
     return child.getId();
+  }
+
+  // 지역 ID 값으로 부모 노드의 이름과 자식 노드의 이름을 추출합니다.
+  public RegionResponseDto findById(Long regionId) {
+
+    Region region = regionRepository.findById(regionId)
+        .orElseThrow(() -> new CustomException(CITY_NOT_FOUND));
+
+    return new RegionResponseDto(region.getParent().getName(), region.getName());
   }
 }

--- a/src/test/java/com/gogym/post/service/GymServiceTest.java
+++ b/src/test/java/com/gogym/post/service/GymServiceTest.java
@@ -1,0 +1,55 @@
+package com.gogym.post.service;
+
+import static com.gogym.post.type.MembershipType.MEMBERSHIP_ONLY;
+import static com.gogym.post.type.PostType.SELL;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.gogym.post.dto.PostRequestDto;
+import com.gogym.post.entity.Gym;
+import com.gogym.post.repository.GymRepository;
+import com.gogym.region.service.RegionService;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GymServiceTest {
+
+  @Mock
+  private GymRepository gymRepository;
+
+  @Mock
+  private RegionService regionService;
+
+  @InjectMocks
+  private GymService gymService;
+
+  private PostRequestDto postRequestDto;
+
+  @BeforeEach
+  void setUp() {
+    postRequestDto = new PostRequestDto("제목", "내용", SELL, MEMBERSHIP_ONLY,
+        LocalDate.now().plusMonths(10), null, 1000L,
+        "url1", "url2", "url3",
+        "테스트 헬스장", 1.1, 2.2,
+        "url", "도시", "지역");
+  }
+
+  @Test
+  void 헬스장이_존재하지_않는_경우_헬스장을_저장한다() {
+    // given
+    when(regionService.getChildRegionId("도시", "지역")).thenReturn(1L);
+    when(gymRepository.findByLatitudeAndLongitude(postRequestDto.latitude(), postRequestDto.longitude())).thenReturn(Optional.empty());
+    // when
+    gymService.findOrCreateGym(postRequestDto);
+    // then
+    verify(gymRepository).save(any(Gym.class));
+  }
+}

--- a/src/test/java/com/gogym/post/service/PostServiceTest.java
+++ b/src/test/java/com/gogym/post/service/PostServiceTest.java
@@ -1,19 +1,29 @@
 package com.gogym.post.service;
 
+import static com.gogym.exception.ErrorCode.POST_NOT_FOUND;
 import static com.gogym.post.type.MembershipType.MEMBERSHIP_ONLY;
+import static com.gogym.post.type.PostStatus.POSTING;
 import static com.gogym.post.type.PostType.SELL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.gogym.exception.CustomException;
 import com.gogym.member.entity.Member;
 import com.gogym.member.repository.MemberRepository;
 import com.gogym.member.service.MemberService;
+import com.gogym.post.dto.PostPageResponseDto;
 import com.gogym.post.dto.PostRequestDto;
+import com.gogym.post.dto.PostResponseDto;
 import com.gogym.post.entity.Gym;
 import com.gogym.post.entity.Post;
 import com.gogym.post.repository.GymRepository;
 import com.gogym.post.repository.PostRepository;
+import com.gogym.region.dto.RegionResponseDto;
 import com.gogym.region.entity.Region;
 import com.gogym.region.service.RegionService;
 import java.time.LocalDate;
@@ -26,6 +36,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -48,6 +59,9 @@ class PostServiceTest {
 
   @Mock
   private MemberService memberService;
+
+  @Mock
+  private RegionResponseDto regionResponseDto;
 
   @InjectMocks
   private PostService postService;
@@ -107,6 +121,7 @@ class PostServiceTest {
     when(memberService.findById(member.getId())).thenReturn(member);
     when(gymRepository.findByLatitudeAndLongitude(postRequestDto.latitude(),
         postRequestDto.longitude())).thenReturn(Optional.of(gym));
+    when(regionService.findById(gym.getRegionId())).thenReturn(regionResponseDto);
     // when
     postService.createPost(member.getId(), postRequestDto);
     // then
@@ -120,10 +135,85 @@ class PostServiceTest {
     when(gymRepository.findByLatitudeAndLongitude(postRequestDto.latitude(),
         postRequestDto.longitude())).thenReturn(Optional.empty());
     when(gymRepository.save(any(Gym.class))).thenReturn(gym);
+    when(regionService.findById(gym.getRegionId())).thenReturn(regionResponseDto);
     // when
     postService.createPost(member.getId(), postRequestDto);
     // then
     verify(gymRepository).save(any(Gym.class));
     verify(postRepository).save(any());
+  }
+
+  @Test
+  void 비회원이_게시글_목록을_조회한다() {
+    // given
+    posts = new PageImpl<>(List.of(post), pageable, 1);
+
+    when(postRepository.findAllByStatus(pageable, POSTING)).thenReturn(posts);
+    // when
+    Page<PostPageResponseDto> result = postService.getAllPostsOfGuest(pageable);
+    // then
+    assertNotNull(result);
+    assertEquals(result.getTotalElements(), 1);
+    assertEquals(result.getContent().get(0).title(), "게시글 제목");
+  }
+
+  @Test
+  void 회원이_게시글_목록을_조회한다() {
+    // given
+    posts = new PageImpl<>(List.of(post), pageable, 1);
+
+    when(memberService.findById(member.getId())).thenReturn(member);
+    when(postRepository.findAllByStatusAndRegionIds(POSTING, pageable, regionIds)).thenReturn(
+        posts);
+    // when
+    Page<PostPageResponseDto> result = postService.getAllPostsOfMember(member.getId(), pageable);
+    // then
+    assertNotNull(result);
+    assertEquals(result.getTotalElements(), 1);
+    assertEquals(result.getContent().get(0).title(), "게시글 제목");
+  }
+
+  @Test
+  void 회원의_지역이_설정이_되지_않고_해당_지역에_등록된_게시글이_없으면_빈_배열을_반환한다() {
+    // given
+    posts = new PageImpl<>(List.of(post), pageable, 1);
+    member = Member.builder()
+        .id(1L)
+        .regionId1(null)
+        .regionId2(null)
+        .build();
+
+    when(memberService.findById(member.getId())).thenReturn(member);
+    // when
+    Page<PostPageResponseDto> result = postService.getAllPostsOfMember(member.getId(), pageable);
+    // then
+    assertNotNull(result);
+    assertEquals(result.getTotalElements(), 0);
+    assertTrue(result.getContent().isEmpty());
+  }
+
+  @Test
+  void 게시글을_조회한다() {
+    // given
+    when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
+    when(regionService.findById(gym.getRegionId())).thenReturn(regionResponseDto);
+    // when
+    PostResponseDto result = postService.getDetailPost(post.getId());
+    // then
+    assertNotNull(result);
+    assertEquals(result.title(), post.getTitle());
+    assertEquals(result.gymName(), post.getGym().getGymName());
+  }
+
+  @Test
+  void 게시글이_없는_경우_조회에_실패한다() {
+    // given
+    when(postRepository.findById(post.getId())).thenReturn(Optional.empty());
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> postService.getDetailPost(post.getId()));
+    // then
+    assertEquals(e.getErrorCode(), POST_NOT_FOUND);
+    assertEquals(e.getMessage(), "게시글을 찾을 수 없습니다.");
   }
 }

--- a/src/test/java/com/gogym/post/service/PostServiceTest.java
+++ b/src/test/java/com/gogym/post/service/PostServiceTest.java
@@ -52,6 +52,9 @@ class PostServiceTest {
   private MemberRepository memberRepository;
 
   @Mock
+  private GymService gymService;
+
+  @Mock
   private GymRepository gymRepository;
 
   @Mock
@@ -119,27 +122,11 @@ class PostServiceTest {
   void 헬스장이_존재하는_경우_성공적으로_게시글을_작성한다() {
     // given
     when(memberService.findById(member.getId())).thenReturn(member);
-    when(gymRepository.findByLatitudeAndLongitude(postRequestDto.latitude(),
-        postRequestDto.longitude())).thenReturn(Optional.of(gym));
+    when(gymService.findOrCreateGym(postRequestDto)).thenReturn(gym);
     when(regionService.findById(gym.getRegionId())).thenReturn(regionResponseDto);
     // when
     postService.createPost(member.getId(), postRequestDto);
     // then
-    verify(postRepository).save(any());
-  }
-
-  @Test
-  void 헬스장이_존재하지_않는_경우_헬스장을_저장한다() {
-    // given
-    when(memberService.findById(member.getId())).thenReturn(member);
-    when(gymRepository.findByLatitudeAndLongitude(postRequestDto.latitude(),
-        postRequestDto.longitude())).thenReturn(Optional.empty());
-    when(gymRepository.save(any(Gym.class))).thenReturn(gym);
-    when(regionService.findById(gym.getRegionId())).thenReturn(regionResponseDto);
-    // when
-    postService.createPost(member.getId(), postRequestDto);
-    // then
-    verify(gymRepository).save(any(Gym.class));
     verify(postRepository).save(any());
   }
 

--- a/src/test/java/com/gogym/post/service/PostServiceTest.java
+++ b/src/test/java/com/gogym/post/service/PostServiceTest.java
@@ -150,7 +150,7 @@ class PostServiceTest {
 
     when(postRepository.findAllByStatus(pageable, POSTING)).thenReturn(posts);
     // when
-    Page<PostPageResponseDto> result = postService.getAllPostsOfGuest(pageable);
+    Page<PostPageResponseDto> result = postService.getAllPosts(null, pageable);
     // then
     assertNotNull(result);
     assertEquals(result.getTotalElements(), 1);
@@ -166,7 +166,7 @@ class PostServiceTest {
     when(postRepository.findAllByStatusAndRegionIds(POSTING, pageable, regionIds)).thenReturn(
         posts);
     // when
-    Page<PostPageResponseDto> result = postService.getAllPostsOfMember(member.getId(), pageable);
+    Page<PostPageResponseDto> result = postService.getAllPosts(member.getId(), pageable);
     // then
     assertNotNull(result);
     assertEquals(result.getTotalElements(), 1);
@@ -185,7 +185,7 @@ class PostServiceTest {
 
     when(memberService.findById(member.getId())).thenReturn(member);
     // when
-    Page<PostPageResponseDto> result = postService.getAllPostsOfMember(member.getId(), pageable);
+    Page<PostPageResponseDto> result = postService.getAllPosts(member.getId(), pageable);
     // then
     assertNotNull(result);
     assertEquals(result.getTotalElements(), 0);

--- a/src/test/java/com/gogym/region/service/RegionServiceTest.java
+++ b/src/test/java/com/gogym/region/service/RegionServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import com.gogym.exception.CustomException;
 import com.gogym.region.dto.RegionDto;
+import com.gogym.region.dto.RegionResponseDto;
 import com.gogym.region.entity.Region;
 import com.gogym.region.repository.RegionRepository;
 import java.util.ArrayList;
@@ -96,7 +97,8 @@ class RegionServiceTest {
     String district = "강북구 ";
 
     when(regionRepository.findByName(city)).thenReturn(Optional.of(seoulParent));
-    when(regionRepository.findByNameAndParentId(district, seoulParent.getId())).thenReturn(Optional.empty());
+    when(regionRepository.findByNameAndParentId(district, seoulParent.getId())).thenReturn(
+        Optional.empty());
     // when
     CustomException e = assertThrows(CustomException.class,
         () -> regionService.getChildRegionId(city, district));
@@ -116,5 +118,18 @@ class RegionServiceTest {
     // then
     assertEquals(e.getErrorCode(), CITY_NOT_FOUND);
     assertEquals(e.getMessage(), "도시를 찾을 수 없습니다.");
+  }
+
+  @Test
+  void 하위지역의_아이디로_상위지역의_이름과_하위지역의_이름을_반환한다() {
+    // given
+    Long regionId = 2L;
+    when(regionRepository.findById(regionId)).thenReturn(Optional.of(seoulChild1));
+    // when
+    RegionResponseDto region = regionService.findById(regionId);
+    // then
+    assertEquals(regionId, seoulChild1.getId());
+    assertEquals(region.district(), seoulChild1.getName());
+    assertEquals(region.city(), seoulChild1.getParent().getName());
   }
 }


### PR DESCRIPTION
## ⚡️ Issue 번호
<!-- 작업한 내용에 해당하는 Issue 번호를 꼭! 기록해주세요 !
키워드: close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved
예시: close #10 !-->
- 게시판관련 (게시판 목록(조회), 게시판 목록(필터), 게시글 상세) #36 

## 🛠️ 작업 내용 (What)
- 게시판 목록, 게시판 필터링, 게시글 상세 조회 등 구현

## 📌 작업 이유 (Why)
- 비회원도 게시글 목록을 조회할 수 있어야 합니다.
- 비회원도 게시글 상세를 조회할 수 있어야 합니다.
- 회원 즉, 로그인 된 경우, 관심지역이 설정이 된 경우라면 관심지역을 기준으로 게시글 목록이 조회가 됩니다.
- 비회원도 게시글을 필터링 하여 조회할 수 있습니다.
- 회원도 관심지역의 유무와 상관없이 필터링 할 수 있습니다.

## ✨ 변경 사항 (Changes)
- 공통
  - Query DSL 을 사용하여 복잡한 필터링 조건을 해결하기 위해 사용했습니다.
  - Query DSL Builder 패턴으로, 필터값이 null 이면 필터에 추가되지 않고, 파라미터 값이 존재하면 필터에 추가됩니다.
  - 타 도메인에서 PostService 에 접근하여 게시글의 ID 를 찾을 수 있습니다.
  - 타 도메인에서 PostService 에 접근하여 게시글의 작성자를 찾을 수 있습니다.
- 게시글 목록 -> 페이징 처리
  - 비회원도 게시글을 조회할 수 있습니다.
  - 회원도 게시글을 조회하지만, 관심지역이 등록 된 경우, 관심지역을 기준으로 조회됩니다.
  - 회원의 관심지역이 설정되지 않은 경우 비회원과 같은 전체 목록을 반환합니다.
  - 조회한 결과가 없다면 빈 배열을 반환합니다.
- 게시글 필터링 -> 페이징 처리
  - 비회원도 게시글을 필터링 할 수 있습니다.
  - 회원의 관심지역이 등록이 되어 있다면, 기본적으로 관심지역 기준으로 필터링 됩니다.
  - 필터링의 경우 Query DSL 을 사용하여 필터링 합니다.
  - 필터링의 기준은 게시글 타입, 멤버십 타입, 게시글 상태, 남은 개월수, PT 남은 횟수 로 필터링 됩니다.
  - 회원권이 남은 개월수와 PT 남은 횟수 는 FE 에서 기간과 횟수를 계산 후에 고정된 Enum 값으로 전달하여 서버에서 DB 를 조회하여 처리합니다.
  - 필터링 된 결과가 없다면 빈 배열을 반환합니다.
- 게시글 상세
  - 비회원도 게시글 상세 페이지를 조회할 수 있습니다.
  - 게시글이 삭제된 경우 게시글 조회가 불가능합니다.

## ✅ 테스트 (Tests)
- [ ] 하위지역의 아이디로 상위지역의 이름과 하위지역의 이름을 반환한다
- [ ] 비회원이 게시글 목록을 조회한다
- [ ] 회원이 게시글 목록을 조회한다
- [ ] 회원의 지역이 설정이 되지 않고 해당 지역에 등록된 게시글이 없으면 빈 배열을 반환한다
- [ ] 게시글을 조회한다
- [ ] 게시글이 없는 경우 조회에 실패한다

## ♻️ 추가 Refactor 사항
 - 게시글 생성후, 등록한 지역도 같이 반환해주는 것이 좋다고 생각하여 상위지역과 하위 지역을 찾은 후, 반환합니다.(공톨로직으로 게시글 상세에 사용되며, 게시글 수정에도 사용될 예정입니다.)

## 💬 리뷰 포인트 (Review Points)
@ModelAttribute 를 사용하여 필터 값을 DTO 로 받아오고, DTO 에서 @JsonProperty, @RequestParam 등으로 처리하려 했으나,
실제로 적용 테스트를 해보니 null 값으로 넘어갔습니다. 

DTO 를 클래스로 변경할까 라고도 생각했으나, 
DTO 형식을 record 로 맞추는게 통일성이 좋다고 생각하여
 컨트롤러에서 @RequestParam 으로 개별 필드를 처리 후, DTO 에 담아 Service layer 로 넘기는 것으로 구현했습니다.

 해당 방식 말고 다른 좋은 방식이 있으시다면 공유해주시면 좋을 것 같습니다!