### PR TITLE
✨️feat : 채팅방 관리 기능 구현

### DIFF
--- a/src/main/java/com/gogym/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/gogym/chat/controller/ChatRoomController.java
@@ -1,0 +1,97 @@
+package com.gogym.chat.controller;
+
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import com.gogym.chat.dto.ChatRoomDto.ChatRoomResponse;
+import com.gogym.chat.dto.ChatRoomDto.LeaveRequest;
+import com.gogym.chat.service.ChatRoomService;
+import com.gogym.common.annotation.LoginMemberId;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chatroom")
+public class ChatRoomController {
+  
+  private final ChatRoomService chatRoomService;
+  
+  /**
+   * 특정 게시글에 대한 채팅방을 생성합니다.
+   * 
+   * POST /api/chatroom/{post-id}
+   * 
+   * @param memberId 요청자 ID
+   * @param postId 채팅방을 생성할 게시글 ID
+   * @return 생성된 {@link ChatRoomResponse} 객체를 포함한 {@link ResponseEntity}.
+   */
+  @PostMapping("/{post-id}")
+  public ResponseEntity<ChatRoomResponse> createChatRoom(
+      @LoginMemberId Long memberId,
+      @PathVariable("post-id") Long postId) {
+    return ResponseEntity.ok(this.chatRoomService.createChatroom(memberId, postId));
+  }
+  
+  /**
+   * 사용자가 참여한 채팅방 목록을 페이지네이션하여 조회합니다.
+   * 
+   * GET /api/chatroom?page={page}&size={size}
+   * 
+   * @param memberId 요청자 ID
+   * @param page 조회할 페이지 번호
+   * @param size 페이지당 항목 수
+   * @return {@link ChatroomResponse} 객체 리스트를 포함한 {@link ResponseEntity}.
+   */
+  @GetMapping
+  public ResponseEntity<List<ChatRoomResponse>> getChatRooms(
+      @LoginMemberId Long memberId,
+      @RequestParam("page") int page,
+      @RequestParam("size") int size) {
+    return ResponseEntity.ok(this.chatRoomService.getChatRooms(memberId, page, size));
+  }
+  
+  /**
+   * 사용자가 채팅방에서 나갈 때 마지막 읽은 메시지를 업데이트합니다.
+   * 
+   * POST /api/chatroom/{chatroom-id}/leave
+   * 
+   * @param memberId 요청자 ID
+   * @param chatroomId 나갈 채팅방 ID.
+   * @param request 탈퇴 요청 세부 정보를 포함한 {@link LeaveRequest}.
+   * @return 성공 상태를 나타내는 {@link ResponseEntity}.
+   */
+  @PostMapping("/{chatroom-id}/leave")
+  public ResponseEntity<Void> leaveChatRoom(
+      @LoginMemberId Long memberId,
+      @PathVariable("chatroom-id") Long chatRoomId,
+      @Valid @RequestBody LeaveRequest request) {
+    this.chatRoomService.leaveChatRoom(memberId, chatRoomId, request);
+    return ResponseEntity.ok().build();
+  }
+  
+  /**
+   * 특정 채팅방을 삭제합니다.
+   * 
+   * DELETE /api/chatroom/{chatroom-id}
+   * 
+   * @param memberId 요청자 ID
+   * @param chatroomId 삭제할 채팅방 ID
+   * @return 성공 상태를 나타내는 {@link ResponseEntity}.
+   */
+  @DeleteMapping("/{chatroom-id}")
+  public ResponseEntity<Void> deleteChatRoom(
+      @LoginMemberId Long memberId,
+      @PathVariable("chatroom-id") Long chatRoomId) {
+    this.chatRoomService.deleteChatRoom(memberId, chatRoomId);
+    return ResponseEntity.ok().build();
+  }
+  
+}

--- a/src/main/java/com/gogym/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/gogym/chat/controller/ChatRoomController.java
@@ -37,7 +37,7 @@ public class ChatRoomController {
   public ResponseEntity<ChatRoomResponse> createChatRoom(
       @LoginMemberId Long memberId,
       @PathVariable("post-id") Long postId) {
-    return ResponseEntity.ok(this.chatRoomService.createChatroom(memberId, postId));
+    return ResponseEntity.ok(this.chatRoomService.createChatRoom(memberId, postId));
   }
   
   /**

--- a/src/main/java/com/gogym/chat/entity/ChatMessage.java
+++ b/src/main/java/com/gogym/chat/entity/ChatMessage.java
@@ -12,6 +12,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "chat_messages")
@@ -23,12 +24,13 @@ public class ChatMessage extends BaseEntity {
   
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "chat_room_id", nullable = false)
+  @Setter
   private ChatRoom chatRoom; // 메시지가 속한 채팅방
   
   @Column(name = "content", nullable = false, columnDefinition = "TEXT")
   private String content; // 메시지 내용
   
   @Column(name = "sender_id", nullable = false)
-  private Long senderId; // 메시지 보낸 사용자 ID (nullable)
+  private Long senderId; // 메시지 보낸 사용자 ID
   
 }

--- a/src/main/java/com/gogym/chat/entity/ChatRoom.java
+++ b/src/main/java/com/gogym/chat/entity/ChatRoom.java
@@ -1,14 +1,20 @@
 package com.gogym.chat.entity;
 
 import com.gogym.common.entity.BaseEntity;
+import com.gogym.member.entity.Member;
+import com.gogym.post.entity.Post;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "chatrooms")
@@ -18,13 +24,31 @@ import lombok.NoArgsConstructor;
 @Builder
 public class ChatRoom extends BaseEntity {
   
-  @Column(name = "post_id", nullable = false)
-  private Long postId; // 게시글 작성자 ID
+  @JoinColumn(name = "post_id", nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
+  private Post post; // 게시글 작성자
   
-  @Column(name = "request_id", nullable = false)
-  private Long requestId; // 채팅 요청자 ID
+  @JoinColumn(name = "request_id", nullable = false)
+  @ManyToOne(fetch = FetchType.LAZY)
+  private Member requestor; // 채팅 요청자
   
   @Column(name = "is_deleted", nullable = false)
+  @Setter
   private Boolean isDeleted; // 삭제 여부
+  
+  @Column(name = "post_author_active", nullable = false)
+  @Builder.Default
+  @Setter
+  private Boolean postAuthorActive = true; // 게시글 작성자의 채팅방 활성화 여부
+  
+  @Column(name = "requestor_active", nullable = true)
+  @Builder.Default
+  @Setter
+  private Boolean requestorActive = true; // 채팅 요청자의 채팅방 활성화 여부
+  
+  // 게시글 작성자 반환 메서드
+  public Member getPostAuthor() {
+    return this.post.getMember();
+  }
   
 }

--- a/src/main/java/com/gogym/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/gogym/chat/repository/ChatRoomRepository.java
@@ -12,29 +12,29 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
    * 특정 게시글과 요청자의 채팅방 존재 여부 확인.
    *
    * @param postId 게시글 ID
-   * @param requestId 요청자 ID
+   * @param requestorId 요청자 ID
    * @return 채팅방 존재 여부
    */
-  boolean existsByPostIdAndRequestId(Long postId, Long requestId);
+  boolean existsByPostIdAndRequestorId(Long postId, Long requestorId);
   
   /**
    * 특정 사용자가 참여한 채팅방 목록 조회.
    *
-   * @param postId 게시글 ID
-   * @param requestId 요청자 ID
+   * @param postAuthorId 게시글 작성자 ID
+   * @param requestorId 요청자 ID
    * @param pageable 페이징 정보
    * @return 참여한 채팅방 목록 (Page)
    */
-  Page<ChatRoom> findByPostIdOrRequestId(Long postId, Long requestId, Pageable pageable);
+  Page<ChatRoom> findByPostMemberIdOrRequestorIdAndIsDeletedFalse(Long postAuthorId, Long requestorId, Pageable pageable);
   
   /**
    * 사용자가 참여한 특정 채팅방 조회.
    *
    * @param chatRoomId 채팅방 ID
-   * @param postId 게시글 ID
-   * @param requestId 요청자 ID
+   * @param postAuthorId 게시글 작성자 ID
+   * @param requestorId 요청자 ID
    * @return 특정 채팅방 (Optional)
    */
-  Optional<ChatRoom> findByIdAndPostIdOrRequestId(Long chatRoomId, Long postId, Long requestId);
+  Optional<ChatRoom> findByIdAndPostMemberIdOrRequestorId(Long chatRoomId, Long postAuthorId, Long requestorId);
   
 }

--- a/src/main/java/com/gogym/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/gogym/chat/repository/ChatRoomRepository.java
@@ -4,6 +4,8 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import com.gogym.chat.entity.ChatRoom;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
@@ -18,14 +20,27 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
   boolean existsByPostIdAndRequestorId(Long postId, Long requestorId);
   
   /**
-   * 특정 사용자가 참여한 채팅방 목록 조회.
-   *
+   * 사용자가 참여한 채팅방 목록을 마지막 메시지가 전송된 시간을 기준으로 정렬하여 조회.
+   * 
    * @param postAuthorId 게시글 작성자 ID
    * @param requestorId 요청자 ID
-   * @param pageable 페이징 정보
+   * @param pageable 페이징 및 정렬 정보
    * @return 참여한 채팅방 목록 (Page)
    */
-  Page<ChatRoom> findByPostMemberIdOrRequestorIdAndIsDeletedFalse(Long postAuthorId, Long requestorId, Pageable pageable);
+  @Query("""
+      SELECT cr
+      FROM ChatRoom cr
+      LEFT JOIN ChatMessage cm ON cm.chatRoom.id = cr.id
+      WHERE (cr.postId = :postAuthorId OR cr.requestorId = :requestorId)
+        AND cr.isDeleted = false
+      GROUP BY cr.id
+      ORDER BY MAX(cm.createdAt) DESC
+  """)
+  Page<ChatRoom> findChatRoomsSortedByLastMessage(
+      @Param("postAuthorId") Long postAuthorId,
+      @Param("requestorId") Long requestorId,
+      Pageable pageable
+  );
   
   /**
    * 사용자가 참여한 특정 채팅방 조회.

--- a/src/main/java/com/gogym/chat/service/ChatRedisService.java
+++ b/src/main/java/com/gogym/chat/service/ChatRedisService.java
@@ -1,5 +1,6 @@
 package com.gogym.chat.service;
 
+import java.util.List;
 import com.gogym.chat.dto.ChatMessageDto.ChatMessageRequest;
 import com.gogym.chat.dto.ChatMessageDto.ChatMessageResponse;
 
@@ -12,6 +13,21 @@ public interface ChatRedisService {
    * @return 저장된 메시지 응답
    */
   ChatMessageResponse saveMessageToRedis(ChatMessageRequest messageRequest);
+  
+  /**
+   * Redis에서 특정 채팅방의 메시지 목록을 조회
+   * 
+   * @param chatRoomId 메시지를 조회할 채팅방의 ID
+   * @return Redis에 저장된 메시지 목록
+   */
+  List<String> getMessages(Long chatRoomId);
+  
+  /**
+   * Redis에 저장된 특정 채팅방의 메시지를 삭제
+   * 
+   * @param chatRoomId 저장 및 삭제 대상이 되는 채팅방의 ID
+   */
+  void deleteMessages(Long chatRoomId);
   
   /**
    * Redis에서 채팅방 메시지를 저장할 때 사용하는 키의 접두사를 반환

--- a/src/main/java/com/gogym/chat/service/ChatRoomService.java
+++ b/src/main/java/com/gogym/chat/service/ChatRoomService.java
@@ -1,0 +1,45 @@
+package com.gogym.chat.service;
+
+import java.util.List;
+import com.gogym.chat.dto.ChatRoomDto.ChatRoomResponse;
+import com.gogym.chat.dto.ChatRoomDto.LeaveRequest;
+
+public interface ChatRoomService {
+  
+  /**
+   * 채팅방 생성
+   * 
+   * @param memberId 요청자 ID
+   * @param postId 게시글 ID
+   * @return 생성된 채팅방 정보
+   */
+  ChatRoomResponse createChatroom(Long memberId, Long postId);
+  
+  /**
+   * 사용자가 참여한 채팅방 목록 조회
+   * 
+   * @param memberId 요청자 ID
+   * @param page 페이지 번호
+   * @param size 페이지당 항목 수
+   * @return 사용자가 참여한 채팅 목록
+   */
+  List<ChatRoomResponse> getChatRooms(Long memberId, int page, int size);
+  
+  /**
+   * 채팅방 나가기
+   * 
+   * @param memberId 요청자 ID
+   * @param ChatroomId 채팅방 ID
+   * @param request 나가기 요청 정보
+   */
+  void leaveChatRoom(Long memberId, Long chatRoomId, LeaveRequest request);
+  
+  /**
+   * 채팅방 삭제
+   * 
+   * @param memberId 요청자 ID
+   * @param chatRoomId 채팅방 ID
+   */
+  void deleteChatRoom(Long memberId, Long chatRoomId);
+  
+}

--- a/src/main/java/com/gogym/chat/service/ChatRoomService.java
+++ b/src/main/java/com/gogym/chat/service/ChatRoomService.java
@@ -13,7 +13,7 @@ public interface ChatRoomService {
    * @param postId 게시글 ID
    * @return 생성된 채팅방 정보
    */
-  ChatRoomResponse createChatroom(Long memberId, Long postId);
+  ChatRoomResponse createChatRoom(Long memberId, Long postId);
   
   /**
    * 사용자가 참여한 채팅방 목록 조회

--- a/src/main/java/com/gogym/chat/service/impl/ChatRedisServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRedisServiceImpl.java
@@ -2,6 +2,7 @@ package com.gogym.chat.service.impl;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.gogym.chat.dto.ChatMessageDto.ChatMessageHistory;
@@ -40,7 +41,7 @@ public class ChatRedisServiceImpl implements ChatRedisService {
     String messageJson = JsonUtil.serialize(messageHistory);
 
     // Redis에 저장
-    this.redisUtil.lpush(redisKey, messageJson);
+    this.redisUtil.rpush(redisKey, messageJson);
 
     // 메시지 저장 결과 반환
     return new ChatMessageResponse(
@@ -48,6 +49,18 @@ public class ChatRedisServiceImpl implements ChatRedisService {
         messageRequest.senderId(),
         messageRequest.content(),
         LocalDateTime.parse(createdAt, DATE_TIME_FORMATTER));
+  }
+  
+  @Override
+  public List<String> getMessages(Long chatRoomId) {
+    String redisKey = this.getRedisChatroomMessageKeyPrefix() + chatRoomId;
+    return this.redisUtil.lrange(redisKey, 0, -1);
+  }
+  
+  @Override
+  public void deleteMessages(Long chatRoomId) {
+    String redisKey = this.getRedisChatroomMessageKeyPrefix() + chatRoomId;
+    this.redisUtil.delete(redisKey);
   }
 
   @Override

--- a/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
@@ -1,0 +1,247 @@
+package com.gogym.chat.service.impl;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import com.gogym.chat.dto.ChatMessageDto.ChatMessageHistory;
+import com.gogym.chat.dto.ChatRoomDto.ChatRoomResponse;
+import com.gogym.chat.dto.ChatRoomDto.LeaveRequest;
+import com.gogym.chat.entity.ChatMessage;
+import com.gogym.chat.entity.ChatMessageRead;
+import com.gogym.chat.entity.ChatRoom;
+import com.gogym.chat.repository.ChatMessageReadRepository;
+import com.gogym.chat.repository.ChatMessageRepository;
+import com.gogym.chat.repository.ChatRoomRepository;
+import com.gogym.chat.service.ChatRedisService;
+import com.gogym.chat.service.ChatRoomService;
+import com.gogym.exception.CustomException;
+import com.gogym.exception.ErrorCode;
+import com.gogym.member.entity.Member;
+import com.gogym.member.service.MemberService;
+import com.gogym.post.service.PostService;
+import com.gogym.util.JsonUtil;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatRoomServiceImpl implements ChatRoomService {
+  
+  private final ChatRoomRepository chatRoomRepository;
+  private final ChatMessageRepository chatMessageRepository;
+  private final ChatMessageReadRepository chatMessageReadRepository;
+  
+  private final ChatRedisService chatRedisService;
+  private final MemberService memberService;
+  private final PostService postService;
+  
+  @Override
+  public ChatRoomResponse createChatroom(Long memberId, Long postId) {
+    // 게시글 작성자 존재 여부 확인
+    Member postAuthor = this.postService.getPostAuthor(postId);
+    
+    // 이미 존재하는 채팅방 여부 확인
+    if (this.chatRoomRepository.existsByPostIdAndRequestorId(postId, memberId)) {
+      throw new CustomException(ErrorCode.CHATROOM_ALREADY_EXISTS);
+    }
+    
+    // 채팅방 생성 및 저장
+    ChatRoom newChatRoom = ChatRoom.builder()
+        .post(this.postService.findById(postId))
+        .requestor(this.memberService.findById(memberId))
+        .isDeleted(false)
+        .build();
+    this.chatRoomRepository.save(newChatRoom);
+    
+    return new ChatRoomResponse(
+        newChatRoom.getId(), // chatRoomId
+        newChatRoom.getCreatedAt(), // createdAt
+        postId, // postId
+        postAuthor.getId(), // counterpartyId
+        postAuthor.getNickname(), // counterpartyNickname
+        0, // unreadMessageCount
+        null, // lastMessage
+        null); // lastMessageAt
+  }
+  
+  @Override
+  public List<ChatRoomResponse> getChatRooms(Long memberId, int page, int size) {
+    // 페이징 조건으로 사용자가 참여한 채팅방 목록 조회
+    Page<ChatRoom> chatRooms = this.chatRoomRepository.findByPostMemberIdOrRequestorIdAndIsDeletedFalse(
+        memberId,
+        memberId,
+        PageRequest.of(page, size));
+    
+    // 채팅방 목록 데이터 반환
+    return chatRooms.stream().map(chatRoom -> {
+      // 상대방 정보 조회
+      Member counterparty = chatRoom.getRequestor().getId().equals(memberId)
+          ? chatRoom.getPost().getMember() // 게시글 작성자가 상대방인 경우
+          : chatRoom.getRequestor(); // 요청자가 상대방인 경우
+      
+      // 상대방 정보가 없을 경우 추가 방어 로직
+      if (counterparty == null) {
+        throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
+      }
+      
+      // Redis에서 채팅방에 해당하는 메시지들 조회
+      List<String> redisMessages = this.chatRedisService.getMessages(chatRoom.getId());
+      
+      // 마지막 메시지 처리
+      ChatMessage lastMessage = null;
+      LocalDateTime lastMessageAt = null;
+      
+      if (redisMessages != null && !redisMessages.isEmpty()) {
+        // Redis에서 가장 마지막 메시지 가져오기
+        String lastMessageJson = redisMessages.get(redisMessages.size() - 1);
+        ChatMessageHistory lastMessageHistory = JsonUtil.deserialize(lastMessageJson, ChatMessageHistory.class);
+        
+        if (lastMessageHistory != null) {
+          lastMessage = ChatMessage.builder()
+              .content(lastMessageHistory.content())
+              .senderId(lastMessageHistory.senderId())
+              .chatRoom(chatRoom)
+              .build();
+
+          // 메시지 생성 시간 설정
+          lastMessageAt = LocalDateTime.parse(
+              lastMessageHistory.createdAt(),
+              DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        }
+      }
+
+      // Redis에 메시지가 없으면 DB에서 메시지 조회
+      if (lastMessage == null) {
+        ChatMessage dbLastMessage = this.chatMessageRepository.findFirstByChatRoomIdOrderByCreatedAtDesc(chatRoom.getId())
+            .orElse(null);
+
+        if (dbLastMessage != null) {
+          lastMessage = dbLastMessage;
+          lastMessageAt = dbLastMessage.getCreatedAt();
+        }
+      }
+      
+      // 읽지 않은 메시지 개수
+      int unreadMessageCount = this.chatMessageReadRepository.countUnreadMessages(
+          chatRoom.getId(),
+          memberId);
+      
+      // ChatRoomResponse 생성
+      return new ChatRoomResponse(
+          chatRoom.getId(), // chatRoomId
+          chatRoom.getCreatedAt(), // createdAt
+          chatRoom.getPost().getId(), // postId
+          counterparty.getId(), // counterpartyId
+          counterparty.getNickname(), // counterpartyNickname
+          unreadMessageCount, // unreadMessageCount
+          lastMessage != null ? lastMessage.getContent() : null, // lastMessage
+          lastMessageAt); // lastMessageAt
+    }).collect(Collectors.toList());
+  }
+  
+  @Override
+  public void leaveChatRoom(Long memberId, Long chatRoomId, LeaveRequest request) {
+    // 나가려는 채팅방 존재 여부 확인
+    ChatRoom chatRoom = this.chatRoomRepository.findById(chatRoomId)
+        .orElseThrow(() -> new CustomException(ErrorCode.CHATROOM_NOT_FOUND));
+    
+    // 요청자가 채팅방에 속해 있는지 확인
+    if (!chatRoom.getPost().getMember().getId().equals(memberId)
+        && !chatRoom.getRequestor().getId().equals(memberId)) {
+      throw new CustomException(ErrorCode.FORBIDDEN);
+    }
+    
+    // Redis에서 메시지 목록 조회
+    List<String> redisMessages = this.chatRedisService.getMessages(chatRoomId);
+    
+    // Redis 메시지들을 DB에 저장
+    if (redisMessages != null && !redisMessages.isEmpty()) {
+      this.forceSaveMessages(chatRoomId, redisMessages);
+    }
+    
+    // DB에서 가장 최근 메시지 가져오기
+    ChatMessage lastMessage = this.chatMessageRepository.findFirstByChatRoomIdOrderByCreatedAtDesc(chatRoomId)
+        .orElseThrow(() -> new CustomException(ErrorCode.CHAT_MESSAGE_NOT_FOUND));
+    
+    // 마지막으로 읽은 메시지 업데이트
+    ChatMessageRead messageRead = this.chatMessageReadRepository.findByChatRoomAndMemberId(chatRoom, memberId)
+        .orElseGet(() -> ChatMessageRead.builder()
+            .chatRoom(chatRoom)
+            .memberId(memberId)
+            .build());
+    messageRead.setLastReadMessage(lastMessage);
+
+    // 변경된 엔티티 저장
+    this.chatMessageReadRepository.save(messageRead);
+  }
+  
+  @Override
+  public void deleteChatRoom(Long memberId, Long chatRoomId) {
+    // 채팅방 존재 여부 확인
+    ChatRoom chatRoom = this.chatRoomRepository.findById(chatRoomId)
+        .orElseThrow(() -> new CustomException(ErrorCode.CHATROOM_NOT_FOUND));
+    
+    // 회원이 해당 채팅방에 속해 있는지 확인
+    if (!chatRoom.getPost().getMember().getId().equals(memberId)
+        && !chatRoom.getRequestor().getId().equals(memberId)) {
+      throw new CustomException(ErrorCode.FORBIDDEN);
+    }
+    
+    // Redis에서 채팅 메시지 조회
+    List<String> redisMessages = this.chatRedisService.getMessages(chatRoomId);
+    
+    // Redis 메시지를 DB에 저장
+    if (redisMessages != null && !redisMessages.isEmpty()) {
+      this.forceSaveMessages(chatRoomId, redisMessages);
+    }
+    
+    // 회원별 채팅방 활성화 상태 업데이트
+    if (chatRoom.getPost().getMember().getId().equals(memberId)) {
+      chatRoom.setPostAuthorActive(false);
+    } else {
+      chatRoom.setRequestorActive(false);
+    }
+    
+    // 양쪽 모두 나갔다면 채팅방 삭제 상태로 변경
+    if (!chatRoom.getPostAuthorActive() && !chatRoom.getRequestorActive()) {
+      chatRoom.setIsDeleted(true);
+    }
+  }
+  
+  /**
+   * Redis에 저장된 메시지들을 강제로 DB에 저장.
+   * 
+   * @param chatRoomId 채팅방 ID
+   * @param redisMessages Redis 메시지 리스트
+   */
+  private void forceSaveMessages(Long chatRoomId, List<String> redisMessages) {
+    List<ChatMessage> chatMessages = redisMessages.stream()
+        .map(messageJson -> {
+          ChatMessageHistory messageHistory = JsonUtil.deserialize(messageJson, ChatMessageHistory.class);
+          
+          if (messageHistory != null) {
+            // ChatMessageHistory -> ChatMessage 변환
+            return ChatMessage.builder()
+                .content(messageHistory.content())
+                .senderId(messageHistory.senderId())
+                .chatRoom(this.chatRoomRepository.getReferenceById(chatRoomId))
+                .build();
+            }
+          return null;
+        })
+        .filter(chatMessage -> chatMessage != null)
+        .collect(Collectors.toList());
+
+    // DB에 저장
+    this.chatMessageRepository.saveAll(chatMessages);
+
+    // Redis 메시지 삭제
+    this.chatRedisService.deleteMessages(chatRoomId);
+  }
+
+}

--- a/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
@@ -72,7 +72,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   @Override
   public List<ChatRoomResponse> getChatRooms(Long memberId, int page, int size) {
     // 페이징 조건으로 사용자가 참여한 채팅방 목록 조회
-    Page<ChatRoom> chatRooms = this.chatRoomRepository.findByPostMemberIdOrRequestorIdAndIsDeletedFalse(
+    Page<ChatRoom> chatRooms = this.chatRoomRepository.findChatRoomsSortedByLastMessage(
         memberId,
         memberId,
         PageRequest.of(page, size));

--- a/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
@@ -41,7 +41,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   private final PostService postService;
   
   @Override
-  public ChatRoomResponse createChatroom(Long memberId, Long postId) {
+  public ChatRoomResponse createChatRoom(Long memberId, Long postId) {
     // 게시글 작성자 존재 여부 확인
     Member postAuthor = this.postService.getPostAuthor(postId);
     

--- a/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
@@ -195,15 +195,16 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     // Redis에서 채팅 메시지 조회
     List<String> redisMessages = this.chatRedisService.getMessages(chatRoomId);
     
-    // Redis 메시지를 DB에 저장
+    // Redis에 메시지가 존재할 경우 DB에 메시지 저장 및 Redis에서 삭제
     if (redisMessages != null && !redisMessages.isEmpty()) {
       this.forceSaveMessages(chatRoomId, redisMessages);
+      this.chatRedisService.deleteMessages(chatRoomId);
     }
     
     // 회원별 채팅방 활성화 상태 업데이트
     if (chatRoom.getPost().getMember().getId().equals(memberId)) {
       chatRoom.setPostAuthorActive(false);
-    } else {
+    } else if (chatRoom.getRequestor().getId().equals(memberId)) {
       chatRoom.setRequestorActive(false);
     }
     
@@ -239,9 +240,6 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
     // DB에 저장
     this.chatMessageRepository.saveAll(chatMessages);
-
-    // Redis 메시지 삭제
-    this.chatRedisService.deleteMessages(chatRoomId);
   }
 
 }

--- a/src/main/java/com/gogym/config/WebSocketConfig.java
+++ b/src/main/java/com/gogym/config/WebSocketConfig.java
@@ -21,7 +21,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
     // WebSocket 연결 endpoint 설정(SockJS 사용)
-    registry.addEndpoint("/ws").setAllowedOriginPatterns("http://localhost:3000").withSockJS();
+    registry.addEndpoint("/ws").setAllowedOriginPatterns("https://gogym-eight.vercel.app/").withSockJS();
   }
   
 }

--- a/src/main/java/com/gogym/util/RedisUtil.java
+++ b/src/main/java/com/gogym/util/RedisUtil.java
@@ -27,6 +27,10 @@ public class RedisUtil {
   public void lpush(String key, String value) {
     redisTemplate.opsForList().leftPush(key, value);
   }
+  
+  public void rpush(String key, String value) {
+    redisTemplate.opsForList().rightPush(key, value);
+  }
 
   public List<String> lrange(String key, long start, long end) {
     return redisTemplate.opsForList().range(key, start, end);

--- a/src/test/java/com/gogym/chat/service/impl/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/gogym/chat/service/impl/ChatRoomServiceImplTest.java
@@ -1,0 +1,290 @@
+package com.gogym.chat.service.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import com.gogym.chat.dto.ChatRoomDto.ChatRoomResponse;
+import com.gogym.chat.dto.ChatRoomDto.LeaveRequest;
+import com.gogym.chat.entity.ChatMessage;
+import com.gogym.chat.entity.ChatRoom;
+import com.gogym.chat.repository.ChatMessageReadRepository;
+import com.gogym.chat.repository.ChatMessageRepository;
+import com.gogym.chat.repository.ChatRoomRepository;
+import com.gogym.common.entity.BaseEntity;
+import com.gogym.exception.CustomException;
+import com.gogym.exception.ErrorCode;
+import com.gogym.member.entity.Member;
+import com.gogym.member.service.MemberService;
+import com.gogym.post.entity.Post;
+import com.gogym.post.service.PostService;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomServiceImplTest {
+
+  @Mock
+  private ChatRoomRepository chatRoomRepository;
+
+  @Mock
+  private ChatMessageRepository chatMessageRepository;
+
+  @Mock
+  private ChatMessageReadRepository chatMessageReadRepository;
+
+  @Mock
+  private MemberService memberService;
+
+  @Mock
+  private PostService postService;
+
+  @Mock
+  private ChatRedisServiceImpl chatRedisService;
+
+  @InjectMocks
+  private ChatRoomServiceImpl chatRoomService;
+
+  private Member postAuthor;
+  private Member requestor;
+  private Post post;
+  private ChatRoom chatRoom;
+  private ChatMessage chatMessage;
+
+  @BeforeEach
+  void setUp() {
+    this.postAuthor = Member.builder()
+        .id(1L)
+        .nickname("PostAuthor")
+        .build();
+
+    this.requestor = Member.builder()
+        .id(2L)
+        .nickname("Requestor")
+        .build();
+    
+    this.post = Post.builder()
+        .member(this.postAuthor)
+        .build();
+    
+    this.chatRoom = ChatRoom.builder()
+        .post(this.post)
+        .requestor(this.requestor)
+        .postAuthorActive(true)
+        .requestorActive(true)
+        .isDeleted(false)
+        .build();
+    
+    this.chatMessage = ChatMessage.builder()
+        .content("test message content")
+        .senderId(this.postAuthor.getId())
+        .chatRoom(this.chatRoom)
+        .build();
+  }
+
+  @Test
+  void 채팅방_생성_성공() {
+    // Given
+    Long postId = 1L;
+    Post mockPost = null;
+
+    when(this.postService.getPostAuthor(postId)).thenReturn(this.postAuthor);
+    when(this.postService.findById(postId)).thenReturn(mockPost);
+
+    // 이미 존재하는 채팅방 여부 확인
+    when(this.chatRoomRepository.existsByPostIdAndRequestorId(postId, this.postAuthor.getId())).thenReturn(false);
+
+    // ChatRoom 생성 후 저장된 상태로 반환
+    when(this.chatRoomRepository.save(any(ChatRoom.class))).thenAnswer(invocation -> {
+      ChatRoom savedChatRoom = invocation.getArgument(0);
+      Field idField = ChatRoom.class.getSuperclass().getDeclaredField("id");
+      idField.setAccessible(true);
+      idField.set(savedChatRoom, 1L);
+      return savedChatRoom;
+    });
+
+    // When
+    ChatRoomResponse response = this.chatRoomService.createChatroom(this.postAuthor.getId(), postId);
+
+    // Then
+    assertNotNull(response);
+    assertEquals(1L, response.chatRoomId());
+    verify(this.chatRoomRepository).save(any(ChatRoom.class));
+  }
+
+  @Test
+  void 채팅방_생성_실패_이미_존재() {
+    // Given
+    Long postId = 1L;
+
+    when(this.chatRoomRepository.existsByPostIdAndRequestorId(postId, this.postAuthor.getId())).thenReturn(true);
+
+    // When
+    CustomException exception = assertThrows(
+        CustomException.class,
+        () -> this.chatRoomService.createChatroom(this.postAuthor.getId(), postId));
+
+    // Then
+    assertEquals(ErrorCode.CHATROOM_ALREADY_EXISTS, exception.getErrorCode());
+  }
+
+  @Test
+  void 채팅방_목록_조회_성공() throws Exception {
+    // Given
+    Long chatRoomId = 1L;
+    Long memberId = 1L;
+
+    Field idField = BaseEntity.class.getDeclaredField("id");
+    idField.setAccessible(true);
+    idField.set(this.chatRoom, 1L);
+
+    Page<ChatRoom> mockPage = new PageImpl<>(List.of(this.chatRoom));
+    when(this.chatRoomRepository.findByPostMemberIdOrRequestorIdAndIsDeletedFalse(
+        eq(memberId),
+        eq(memberId),
+        any(Pageable.class))).thenReturn(mockPage);
+
+    String redisMessageJson = "{\"content\":\"test message\",\"senderId\":1,\"createdAt\":\"2024-12-10 12:00:00\"}";
+    when(this.chatRedisService.getMessages(chatRoomId)).thenReturn(List.of(redisMessageJson));
+    when(this.chatMessageReadRepository.countUnreadMessages(eq(chatRoomId), eq(memberId))).thenReturn(5);
+
+    // When
+    List<ChatRoomResponse> responses = this.chatRoomService.getChatRooms(memberId, 0, 10);
+
+    // Then
+    assertNotNull(responses);
+    assertEquals(1, responses.size());
+
+    ChatRoomResponse response = responses.get(0);
+    
+    assertEquals(chatRoomId, response.chatRoomId());
+    assertEquals("test message", response.lastMessage());
+    assertEquals(5, response.unreadMessageCount());
+    
+    verify(this.chatRoomRepository).findByPostMemberIdOrRequestorIdAndIsDeletedFalse(
+        eq(memberId),
+        eq(memberId),
+        any(Pageable.class));
+    verify(this.chatRedisService).getMessages(chatRoomId);
+    verify(this.chatMessageReadRepository).countUnreadMessages(chatRoomId, memberId);
+  }
+
+  @Test
+  void 채팅방_나가기_성공() {
+    // Given
+    Long chatRoomId = 1L;
+    LeaveRequest request = new LeaveRequest(1L);
+
+    String redisMessageJson = "{\"content\":\"test message\",\"senderId\":1,\"createdAt\":\"2024-12-10T12:00:00\"}";
+    when(this.chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.of(this.chatRoom));
+    when(this.chatRedisService.getMessages(chatRoomId)).thenReturn(List.of(redisMessageJson));
+    when(this.chatMessageRepository.findFirstByChatRoomIdOrderByCreatedAtDesc(chatRoomId)).thenReturn(Optional.of(this.chatMessage));
+
+    // When
+    assertDoesNotThrow(() -> this.chatRoomService.leaveChatRoom(this.postAuthor.getId(), chatRoomId, request));
+
+    // Then
+    verify(this.chatMessageReadRepository).save(any());
+  }
+
+  @Test
+  void 채팅방_나가기_실패_채팅방_없음() {
+    // Given
+    Long chatRoomId = 1L;
+    LeaveRequest request = new LeaveRequest(1L);
+
+    when(this.chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.empty());
+
+    // When
+    CustomException exception = assertThrows(
+        CustomException.class,
+        () -> this.chatRoomService.leaveChatRoom(this.postAuthor.getId(), chatRoomId, request));
+
+    // Then
+    assertEquals(ErrorCode.CHATROOM_NOT_FOUND, exception.getErrorCode());
+  }
+
+  @Test
+  void 채팅방_삭제_양쪽_사용자가_모두_나간_경우_isDeleted_변경() {
+    // Given
+    Long chatRoomId = 1L;
+    ChatRoom testChatRoom = ChatRoom.builder()
+        .post(this.post)
+        .requestor(this.requestor)
+        .postAuthorActive(false)
+        .requestorActive(false)
+        .isDeleted(false)
+        .build();
+
+    String redisMessageJson = "{\"content\":\"test message\",\"senderId\":1,\"createdAt\":\"2024-12-10T12:00:00\"}";
+    when(this.chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.of(testChatRoom));
+    when(this.chatRedisService.getMessages(chatRoomId))
+        .thenReturn(List.of(redisMessageJson)) // 첫 번째 호출에서는 Redis에 메시지 존재
+        .thenReturn(List.of()); // 두 번째 호출에서는 Redis에 메시지 없음
+
+    // When
+    assertDoesNotThrow(() -> this.chatRoomService.deleteChatRoom(this.postAuthor.getId(), chatRoomId));
+    assertDoesNotThrow(() -> this.chatRoomService.deleteChatRoom(this.requestor.getId(), chatRoomId));
+
+    // Then
+    assertTrue(testChatRoom.getIsDeleted());
+    verify(this.chatRedisService, times(1)).deleteMessages(chatRoomId);
+  }
+
+  @Test
+  void 채팅방_삭제_한쪽_사용자만_나간_경우_isDeleted_유지() {
+    // Given
+    Long chatRoomId = 1L;
+    ChatRoom testChatRoom = ChatRoom.builder()
+        .post(this.post)
+        .requestor(this.requestor)
+        .postAuthorActive(false) // 게시물 작성자만 채팅방을 나간 경우
+        .requestorActive(true)
+        .isDeleted(false)
+        .build();
+
+    String redisMessageJson = "{\"content\":\"test message\",\"senderId\":1,\"createdAt\":\"2024-12-10T12:00:00\"}";
+    when(this.chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.of(testChatRoom));
+    when(this.chatRedisService.getMessages(chatRoomId)).thenReturn(List.of(redisMessageJson));
+
+    // When
+    assertDoesNotThrow(() -> this.chatRoomService.deleteChatRoom(this.postAuthor.getId(), chatRoomId));
+
+    // Then
+    assertFalse(testChatRoom.getIsDeleted());
+  }
+
+  @Test
+  void 채팅방_삭제_실패_채팅방_없음() {
+    // Given
+    Long chatRoomId = 1L;
+
+    when(this.chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.empty());
+
+    // When
+    CustomException exception = assertThrows(
+        CustomException.class,
+        () -> this.chatRoomService.deleteChatRoom(this.postAuthor.getId(), chatRoomId));
+
+    // Then
+    assertEquals(ErrorCode.CHATROOM_NOT_FOUND, exception.getErrorCode());
+  }
+
+}

--- a/src/test/java/com/gogym/chat/service/impl/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/gogym/chat/service/impl/ChatRoomServiceImplTest.java
@@ -121,7 +121,7 @@ class ChatRoomServiceImplTest {
     });
 
     // When
-    ChatRoomResponse response = this.chatRoomService.createChatroom(this.postAuthor.getId(), postId);
+    ChatRoomResponse response = this.chatRoomService.createChatRoom(this.postAuthor.getId(), postId);
 
     // Then
     assertNotNull(response);
@@ -139,7 +139,7 @@ class ChatRoomServiceImplTest {
     // When
     CustomException exception = assertThrows(
         CustomException.class,
-        () -> this.chatRoomService.createChatroom(this.postAuthor.getId(), postId));
+        () -> this.chatRoomService.createChatRoom(this.postAuthor.getId(), postId));
 
     // Then
     assertEquals(ErrorCode.CHATROOM_ALREADY_EXISTS, exception.getErrorCode());

--- a/src/test/java/com/gogym/chat/service/impl/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/gogym/chat/service/impl/ChatRoomServiceImplTest.java
@@ -156,7 +156,7 @@ class ChatRoomServiceImplTest {
     idField.set(this.chatRoom, 1L);
 
     Page<ChatRoom> mockPage = new PageImpl<>(List.of(this.chatRoom));
-    when(this.chatRoomRepository.findByPostMemberIdOrRequestorIdAndIsDeletedFalse(
+    when(this.chatRoomRepository.findChatRoomsSortedByLastMessage(
         eq(memberId),
         eq(memberId),
         any(Pageable.class))).thenReturn(mockPage);
@@ -178,7 +178,7 @@ class ChatRoomServiceImplTest {
     assertEquals("test message", response.lastMessage());
     assertEquals(5, response.unreadMessageCount());
     
-    verify(this.chatRoomRepository).findByPostMemberIdOrRequestorIdAndIsDeletedFalse(
+    verify(this.chatRoomRepository).findChatRoomsSortedByLastMessage(
         eq(memberId),
         eq(memberId),
         any(Pageable.class));


### PR DESCRIPTION
## ⚡️ Issue 번호
채팅방 관련 기능 #33 

## 🛠️ 작업 내용 (What)
- API Endpoint
  - 채팅방 생성
  - 채팅방 목록 조회
  - 채팅방 나가기
  - 채팅방 삭제
- Service Layer
  - ChatRoomService 구현
    - 채팅방 생성(createChatRoom)
    - 채팅방 목록 조회(getChatRooms)
    - 채팅방 나가기(leaveChatRoom)
    - 채팅방 삭제(deleteChatRoom)
  - Redis와 DB 간 데이터 동기화 로직 추가
- Test Code
  - 주요 메서드에 대한 단위 테스트 검증

## 📌 작업 이유 (Why)
- 사용자 간 원활한 채팅을 위해 채팅방 생성, 목록 조회, 나가기, 삭제 기능이 필요합니다.
- 데이터의 일관성을 보장하기 위해 Redis와 DB 간의 메시지 데이터 동기화가 필요합니다.
- 양쪽 사용자 상태에 따라 채팅방의 삭제 여부를 명확히 처리해야 합니다.

## ✨ 변경 사항 (Changes)
- Controller 및 Service 구현
  - ChatRoomController
    - API 엔드포인트 구현
      - `POST /chatroom`: 채팅방 생성.
      - `GET /chatroom`: 채팅방 목록 조회.
      - `POST /chatrooms/{chatroom-id}/leave`: 채팅방 나가기.
      - `DELETE /chatrooms/{chatroom-id}`: 채팅방 삭제.
  - ChatRoomService
    - 채팅방 생성, 목록 조회, 나가기, 삭제를 위한 핵심 로직 구현.
- ChatRoom 및 ChatMessage 엔티티 수정
  - ChatRoom 엔티티
    - 사용자 상태(활성화/비활성화)를 나타내는 필드(postAuthorActive, requestorActive) 추가.
    - Post와 Member와의 연관 관계 매핑 추가.
  - ChatMessage 엔티티:
    - chatRoom 필드에 대한 `@Setter` 추가
- ChatRoomRepository Query 수정
  - 엔티티 수정에 따른 Query 수정.
  - 채팅방 활성화 상태 및 메시지 조회 관련 쿼리 최적화.
- WebSocket 설정 변경
  - 기존 오리진 제한을 완화하여 클라이언트 연결 설정 수정.
- RedisUtil 수정:
  - Redis에 데이터를 추가할 수 있는 rpush 메서드 추가

## ✅ 테스트 (Tests)
- [x] Service Layer Test Code
  - `ChatRoomServiceImpl`의 각 메서드에 대한 단위 테스트 작성.
- [x] API 호출 테스트
  - 채팅방 생성.
  - 채팅방 목록 조회.
  - 채팅방 나가기.
  - 채팅방 삭제.
- [x] 시나리오 테스트
  - 채팅방 생성 후 다른 클라이언트 간의 메시지 송수신 테스트.
  - 메시지 송수신 중 채팅방 목록 조회 시 가장 최근에 보낸 메시지가 조회 되는지 테스트.
  - 채팅방 나가기 시 LastReadMessage 데이터 업데이트가 정상적으로 이루어지는지 테스트.
  - A 유저만 채팅방을 삭제했을 경우 isDeleted 필드가 변경되지 않는지 테스트.
  - A, B 유저 모두 채팅방을 삭제했을 경우 isDeleted 필드가 변경되는지 테스트.
  - 채팅방 삭제 시 DB에 해당 채팅방에 대한 메시지들이 정상적으로 저장되는지 테스트.

## 💬 리뷰 포인트 (Review Points)
- Redis와 DB 동기화
  - Redis와 DB 간 데이터 처리 및 메시지 동기화 로직이 적절한지 검토 부탁드립니다.
  - `forceSaveMessages`메서드와 `deleteMessages` 메서드의 호출 분리에 대한 더 좋은 방안이 있을지 검토 부탁드립니다.
- Test Code Coverage
  - 추가적으로 고려할 Case가 있는지 의견 부탁드립니다.
- Redis 데이터 관리에 대한 고민 논의
  - 현재 채팅 메시지는 Redis에 임시로 저장되며, 이는 데이터의 휘발성 특성 때문에 서버 재시작이나 비정상 종료 시 손실될 가능성이 있다고 생각했습니다. 이에 대해 어떻게 조치하면 좋을지 의견 부탁드립니다.

## 🔍 추가 사항 (Additions)
- WebSocket 연결 시 JWT 인증을 구현하는 방법은 WebSocket 연결 설정 시, HTTP 프로토콜의 Upgrade 요청을 사용하는데, 이 때 JWT를 요청 헤더에 포함하여 서버로 전송하는 방법으로 구현 예정에 있습니다.
- 시나리오 테스트 중 각각 다른 클라이언트 간의 메시지 송수신 테스트를 위해 아래 사진과 같이 테스트 하였습니다.
![image](https://github.com/user-attachments/assets/2b97a17b-e58b-4ff3-9cb8-11a6ec2cbe92)