### PR TITLE
✨ feat: SSE, Webhook 사용한 잔액 충전 기능 개발

### DIFF
--- a/src/main/java/com/gogym/aop/LoggingAspect.java
+++ b/src/main/java/com/gogym/aop/LoggingAspect.java
@@ -1,11 +1,22 @@
 package com.gogym.aop;
 
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.util.ContentCachingRequestWrapper;
 
 @Slf4j
 @Aspect
@@ -13,34 +24,121 @@ import org.springframework.stereotype.Component;
 public class LoggingAspect {
 
   @Pointcut("execution(* com.gogym..controller..*(..))")
-  public void apiLayer() {}
+  public void apiLayer() {
+  }
 
   @Pointcut("execution(* com.gogym..service..*(..)) && !execution(* com.gogym..schedule..*(..)) && !execution(* com.gogym.notification.service.NotificationService.getEmitters(..))")
-  public void serviceLayer() {}
+  public void serviceLayer() {
+  }
 
   @Around("apiLayer()")
   public Object logApiCall(ProceedingJoinPoint joinPoint) throws Throwable {
-    String methodName = joinPoint.getSignature().toShortString();
-    log.info("▶ API 호출 시작: {}", methodName);
+    String transactionId = createTransactionId();
+    HttpServletRequest originalRequest = ((ServletRequestAttributes) RequestContextHolder.getRequestAttributes()).getRequest();
 
-    long startTime = System.currentTimeMillis();
+    ContentCachingRequestWrapper requestWrapper = new ContentCachingRequestWrapper(originalRequest);
+
+    Map<String, Object> params = new HashMap<>();
+    try {
+      params.putAll(getParams(requestWrapper));
+
+      String requestBody = getRequestBody(requestWrapper);
+      if (requestBody != null && !requestBody.isEmpty()) {
+        params.putAll(parseBodyToMap(requestBody));
+      }
+    } catch (Exception e) {
+      log.error("LoggerAspect error", e);
+    }
+
+    log.info("\n[{}] ▶ [Controller] {}.{} 호출 시작\n📍 HTTP Method: {}, URI: {}\n📍 Params: {}\n",
+        transactionId,
+        joinPoint.getSignature().getDeclaringType().getSimpleName(),
+        joinPoint.getSignature().getName(),
+        requestWrapper.getMethod(),
+        requestWrapper.getRequestURI(),
+        params);
+
     Object result = joinPoint.proceed();
-    long endTime = System.currentTimeMillis();
 
-    log.info("◀ API 호출 종료: {}, 실행 시간: {} ms", methodName, endTime - startTime);
     return result;
   }
 
   @Around("serviceLayer()")
   public Object logServiceCall(ProceedingJoinPoint joinPoint) throws Throwable {
+    String transactionId = getTransactionId();
     String methodName = joinPoint.getSignature().toShortString();
-    log.info("▶ 서비스 메서드 시작: {}", methodName);
+    Object[] args = joinPoint.getArgs();
+
+    log.info("\n[{}] ▶ [Service] {} 호출 시작", transactionId, methodName);
+    log.info("📍 매개변수: {}\n", args);
 
     long startTime = System.currentTimeMillis();
     Object result = joinPoint.proceed();
     long endTime = System.currentTimeMillis();
 
-    log.info("◀ 서비스 메서드 종료: {}, 실행 시간: {} ms", methodName, endTime - startTime);
+    log.info("\n[{}] ◀ [Service] {} 호출 종료, 실행 시간: {} ms\n", transactionId, methodName,
+        endTime - startTime);
+
     return result;
+  }
+
+  private Map<String, Object> getParams(HttpServletRequest request) {
+    Map<String, Object> params = new HashMap<>();
+    Enumeration<String> paramNames = request.getParameterNames();
+    while (paramNames.hasMoreElements()) {
+      String param = paramNames.nextElement();
+      String value = request.getParameter(param);
+      if ("password".equalsIgnoreCase(param) || "newPassword".equalsIgnoreCase(param)) {
+        value = "*****";
+      }
+      params.put(param, value);
+    }
+    return params;
+  }
+
+  private String getRequestBody(ContentCachingRequestWrapper request) {
+    try {
+      byte[] content = request.getContentAsByteArray();
+      if (content.length > 0) {
+        return new String(content, StandardCharsets.UTF_8);
+      }
+    } catch (Exception e) {
+      log.error("요청 바디 읽기 중 오류 발생", e);
+    }
+    return null;
+  }
+
+  private Map<String, Object> parseBodyToMap(String body) {
+    Map<String, Object> bodyParams = new HashMap<>();
+    try {
+      String[] pairs = body.split("&");
+      for (String pair : pairs) {
+        String[] keyValue = pair.split("=");
+        if (keyValue.length == 2) {
+          String key = URLDecoder.decode(keyValue[0], StandardCharsets.UTF_8.name());
+          String value = URLDecoder.decode(keyValue[1], StandardCharsets.UTF_8.name());
+          if ("password".equalsIgnoreCase(key) || "newPassword".equalsIgnoreCase(key)) {
+            value = "*****";
+          }
+          bodyParams.put(key, value);
+        }
+      }
+    } catch (Exception e) {
+      log.error("요청 바디 파싱 중 오류 발생", e);
+    }
+    return bodyParams;
+  }
+
+  private String createTransactionId() {
+    String transactionId = UUID.randomUUID().toString().substring(0, 8);
+    RequestContextHolder.getRequestAttributes()
+        .setAttribute("transactionId", transactionId, RequestAttributes.SCOPE_REQUEST);
+    return transactionId;
+  }
+
+  private String getTransactionId() {
+    Object transactionId = RequestContextHolder.getRequestAttributes()
+        .getAttribute("transactionId", RequestAttributes.SCOPE_REQUEST);
+    return transactionId != null ? transactionId.toString() : UUID.randomUUID().toString();
   }
 }

--- a/src/main/java/com/gogym/config/WebClientConfig.java
+++ b/src/main/java/com/gogym/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.gogym.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+  @Bean(name = "portOneClient")
+  public WebClient portOneClient(WebClient.Builder builder) {
+    return builder.baseUrl("https://api.portone.io").build();
+  }
+}

--- a/src/main/java/com/gogym/config/WebhookVerifierConfig.java
+++ b/src/main/java/com/gogym/config/WebhookVerifierConfig.java
@@ -1,0 +1,18 @@
+package com.gogym.config;
+
+import io.portone.sdk.server.webhook.WebhookVerifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class WebhookVerifierConfig {
+
+  @Value("${port-one.webhook.secret}")
+  private String secretKey;
+
+  @Bean
+  public WebhookVerifier webhookVerifier() {
+    return new WebhookVerifier(secretKey);
+  }
+}

--- a/src/main/java/com/gogym/gympay/controller/GymPayController.java
+++ b/src/main/java/com/gogym/gympay/controller/GymPayController.java
@@ -1,0 +1,25 @@
+package com.gogym.gympay.controller;
+
+import com.gogym.gympay.service.GymPayService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/gym-pay")
+public class GymPayController {
+
+  private final GymPayService gymPayService;
+
+  @PostMapping
+  public ResponseEntity<Long> open() {
+    Long gymPayId = gymPayService.save(1L);
+
+    return ResponseEntity.ok(gymPayId);
+  }
+}

--- a/src/main/java/com/gogym/gympay/controller/PaymentController.java
+++ b/src/main/java/com/gogym/gympay/controller/PaymentController.java
@@ -1,0 +1,70 @@
+package com.gogym.gympay.controller;
+
+import static org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gogym.common.annotation.LoginMemberId;
+import com.gogym.gympay.dto.WebhookPayload;
+import com.gogym.gympay.dto.request.PreRegisterRequest;
+import com.gogym.gympay.dto.response.PreRegisterResponse;
+import com.gogym.gympay.service.PaymentService;
+import com.gogym.gympay.service.SSEService;
+import io.portone.sdk.server.webhook.WebhookVerifier;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payments")
+public class PaymentController {
+
+  private final PaymentService paymentService;
+  private final SSEService sseService;
+  private final WebhookVerifier webhookVerifier;
+  private final ObjectMapper objectMapper;
+
+  public static final String HEADER_WEBHOOK_ID = "Webhook-Id";
+  public static final String HEADER_WEBHOOK_SIGNATURE = "Webhook-Signature";
+  public static final String HEADER_WEBHOOK_TIMESTAMP = "Webhook-Timestamp";
+
+  @PostMapping("/pre-register")
+  public ResponseEntity<PreRegisterResponse> preRegister(@LoginMemberId Long memberId,
+      @RequestBody PreRegisterRequest request) {
+    var response = paymentService.save(memberId, request);
+
+    return ResponseEntity.ok(response);
+  }
+
+
+  @GetMapping(value = "/sse/subscribe/{merchant-id}", produces = TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter subscribe(@PathVariable("merchant-id") String merchantId) {
+    return sseService.subscribe(merchantId);
+  }
+
+  @PostMapping("/webhook")
+  public ResponseEntity<Void> handleWebhook(
+      @RequestHeader(HEADER_WEBHOOK_ID) String webhookId,
+      @RequestHeader(HEADER_WEBHOOK_SIGNATURE) String webhookSignature,
+      @RequestHeader(HEADER_WEBHOOK_TIMESTAMP) String webhookTimestamp,
+      @RequestBody String payload) {
+
+    try {
+      webhookVerifier.verify(payload, webhookId, webhookSignature, webhookTimestamp);
+      WebhookPayload webhookPayload = objectMapper.readValue(payload, WebhookPayload.class);
+
+      paymentService.processWebhook(webhookPayload);
+
+      return ResponseEntity.ok().build();
+    } catch (Exception e) {
+      return ResponseEntity.badRequest().build();
+    }
+  }
+}

--- a/src/main/java/com/gogym/gympay/controller/PaymentController.java
+++ b/src/main/java/com/gogym/gympay/controller/PaymentController.java
@@ -44,9 +44,9 @@ public class PaymentController {
   }
 
 
-  @GetMapping(value = "/sse/subscribe/{merchant-id}", produces = TEXT_EVENT_STREAM_VALUE)
-  public SseEmitter subscribe(@PathVariable("merchant-id") String merchantId) {
-    return sseService.subscribe(merchantId);
+  @GetMapping(value = "/sse/subscribe/{payment-id}", produces = TEXT_EVENT_STREAM_VALUE)
+  public SseEmitter subscribe(@PathVariable("payment-id") String paymentId) {
+    return sseService.subscribe(paymentId);
   }
 
   @PostMapping("/webhook")

--- a/src/main/java/com/gogym/gympay/dto/PaymentResult.java
+++ b/src/main/java/com/gogym/gympay/dto/PaymentResult.java
@@ -1,0 +1,97 @@
+package com.gogym.gympay.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.gogym.gympay.entity.Payment;
+import com.gogym.gympay.entity.PaymentAmount;
+import com.gogym.gympay.entity.constant.PaymentMethodType;
+import com.gogym.gympay.entity.constant.PgProvider;
+import com.gogym.gympay.entity.constant.SelectedChannelType;
+import com.gogym.gympay.entity.constant.Status;
+import com.gogym.member.entity.Member;
+import java.time.LocalDateTime;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record PaymentResult(
+    Status status,
+    String id,
+    String merchantId,
+    String storeId,
+    Channel channel,
+    LocalDateTime requestedAt,
+    LocalDateTime paidAt,
+    LocalDateTime cancelledAt,
+    LocalDateTime failedAt,
+    Amount amount,
+    Method method,
+    Failure failure
+) {
+
+  public record Channel(
+      SelectedChannelType type,
+      PgProvider pgProvider,
+      String pgMerchantId
+  ) {
+
+  }
+
+  public record Amount(
+      Long total,
+      Long taxFree,
+      Long vat,
+      Long supply,
+      Long paid,
+      Long discount,
+      Long cancelled,
+      Long cancelledTaxFree
+  ) {
+
+  }
+
+  public record Method(
+      PaymentMethodType type
+  ) {
+
+  }
+
+  public record Failure(
+      String reason,
+      String pgCode,
+      String message
+  ) {
+
+  }
+
+  public Payment toEntity(Member member) {
+    return Payment.builder()
+        .id(id)
+        .merchantId(this.merchantId)
+        .transactionId(this.id)
+        .status(this.status)
+        .storeId(this.storeId)
+        .paymentMethodType(this.method.type)
+        .selectedChannelType(this.channel.type)
+        .pgProvider(this.channel.pgProvider)
+        .pgMerchantId(this.channel.pgMerchantId)
+        .requestedAt(this.requestedAt)
+        .paidAt(this.paidAt)
+        .cancelledAt(this.cancelledAt)
+        .failedAt(this.failedAt)
+        .reason(this.failure != null ? this.failure.reason : null)
+        .failedPgCode(this.failure != null ? this.failure.pgCode : null)
+        .failedPgMessage(this.failure != null ? this.failure.message : null)
+        .paymentAmount(
+            PaymentAmount.builder()
+                .total(this.amount.total)
+                .taxFree(this.amount.taxFree)
+                .vat(this.amount.vat)
+                .supply(this.amount.supply)
+                .paid(this.amount.paid)
+                .discount(this.amount.discount)
+                .cancelled(this.amount.cancelled)
+                .cancelledTaxFree(this.amount.cancelledTaxFree)
+                .build()
+        )
+        .member(member)
+        .build();
+  }
+}

--- a/src/main/java/com/gogym/gympay/dto/TokenInfo.java
+++ b/src/main/java/com/gogym/gympay/dto/TokenInfo.java
@@ -1,0 +1,6 @@
+package com.gogym.gympay.dto;
+
+public record TokenInfo(String accessToken,
+                        String refreshToken) {
+
+}

--- a/src/main/java/com/gogym/gympay/dto/WebhookPayload.java
+++ b/src/main/java/com/gogym/gympay/dto/WebhookPayload.java
@@ -1,0 +1,14 @@
+package com.gogym.gympay.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record WebhookPayload(String type,
+                             String timestamp,
+                             DataPayload data) {
+
+  public record DataPayload(String transactionId,
+                            String paymentId,
+                            String cancellationId) {
+  }
+}

--- a/src/main/java/com/gogym/gympay/dto/request/PreRegisterRequest.java
+++ b/src/main/java/com/gogym/gympay/dto/request/PreRegisterRequest.java
@@ -1,0 +1,4 @@
+package com.gogym.gympay.dto.request;
+
+public record PreRegisterRequest(int amount) {
+}

--- a/src/main/java/com/gogym/gympay/dto/response/FailureResponse.java
+++ b/src/main/java/com/gogym/gympay/dto/response/FailureResponse.java
@@ -1,0 +1,7 @@
+package com.gogym.gympay.dto.response;
+
+public record FailureResponse(String reason,
+                              String pgCode,
+                              String pgMessage) {
+
+}

--- a/src/main/java/com/gogym/gympay/dto/response/PreRegisterResponse.java
+++ b/src/main/java/com/gogym/gympay/dto/response/PreRegisterResponse.java
@@ -1,0 +1,5 @@
+package com.gogym.gympay.dto.response;
+
+public record PreRegisterResponse(String paymentId) {
+
+}

--- a/src/main/java/com/gogym/gympay/entity/GymPay.java
+++ b/src/main/java/com/gogym/gympay/entity/GymPay.java
@@ -1,0 +1,29 @@
+package com.gogym.gympay.entity;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import com.gogym.common.entity.BaseEntity;
+import com.gogym.member.entity.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "gym_pays")
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
+public class GymPay extends BaseEntity {
+
+  private long balance;
+
+  @OneToOne(mappedBy = "gymPay")
+  private Member member;
+
+  public void charge(long amount) {
+    this.balance += amount;
+  }
+}

--- a/src/main/java/com/gogym/gympay/entity/Payment.java
+++ b/src/main/java/com/gogym/gympay/entity/Payment.java
@@ -37,10 +37,10 @@ public class Payment {
   private String id; // 결제 건 id (=주문 번호)
 
   @Setter
-  @Column(name = "transaction_id")
+  @Column(name = "transaction_id", nullable = false)
   private String transactionId; // 결제 건 포트원 채번 아이디 (=결제 고유번호)
 
-  @Column(name = "merchant_id")
+  @Column(name = "merchant_id", nullable = false)
   private String merchantId;
 
   @Enumerated(EnumType.STRING)

--- a/src/main/java/com/gogym/gympay/entity/Payment.java
+++ b/src/main/java/com/gogym/gympay/entity/Payment.java
@@ -1,0 +1,93 @@
+package com.gogym.gympay.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+import com.gogym.gympay.entity.constant.PaymentMethodType;
+import com.gogym.gympay.entity.constant.PgProvider;
+import com.gogym.gympay.entity.constant.SelectedChannelType;
+import com.gogym.gympay.entity.constant.Status;
+import com.gogym.member.entity.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Entity
+@Table(name = "payments")
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Payment {
+
+  @Id
+  @Column(unique = true)
+  private String id; // 결제 건 id (=주문 번호)
+
+  @Setter
+  @Column(name = "transaction_id")
+  private String transactionId; // 결제 건 포트원 채번 아이디 (=결제 고유번호)
+
+  @Column(name = "merchant_id")
+  private String merchantId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Status status; // 상태
+
+  @Column(name = "store_id")
+  private String storeId; // 상점 id
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "payment_method_type")
+  private PaymentMethodType paymentMethodType; // 결제 수단
+
+  @Column(name = "selected_channel_type", nullable = false)
+  private SelectedChannelType selectedChannelType; // 채널 정보
+
+  @Column(name = "pg_provider", nullable = false)
+  private PgProvider pgProvider; // PG사 결제 모듈
+
+  @Column(name = "pg_merchant_id", nullable = false)
+  private String pgMerchantId; // PG사 고객사 식별 아이디
+
+  @Column(name = "requested_at")
+  private LocalDateTime requestedAt; // 요청 시간
+
+  @Column(name = "paid_at")
+  private LocalDateTime paidAt; // 결제 완료 시간
+
+  @Column(name = "cancelled_at")
+  private LocalDateTime cancelledAt; // 결제 취소 시간
+
+  @Column(name = "failed_at")
+  private LocalDateTime failedAt; // 결제 실패 시간
+
+  @Column(name = "failed_reason")
+  private String reason; // 결제 실패 사유
+
+  @Column(name = "failed_pg_code")
+  private String failedPgCode; // PG사 실패 코드
+
+  @Column(name = "failed_pg_message")
+  private String failedPgMessage; // PG사 실패 메세지
+
+  @Embedded
+  private PaymentAmount paymentAmount;
+
+  @OneToOne(fetch = LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+}

--- a/src/main/java/com/gogym/gympay/entity/PaymentAmount.java
+++ b/src/main/java/com/gogym/gympay/entity/PaymentAmount.java
@@ -1,0 +1,34 @@
+package com.gogym.gympay.entity;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = PROTECTED)
+public class PaymentAmount {
+
+  private Long total;
+
+  @Column(name = "tax_free")
+  private Long taxFree;
+
+  private Long vat;
+
+  private Long supply;
+
+  private Long discount;
+
+  private Long paid;
+
+  private Long cancelled;
+
+  @Column(name = "cancelled_tax_free")
+  private Long cancelledTaxFree;
+}

--- a/src/main/java/com/gogym/gympay/entity/PaymentAmount.java
+++ b/src/main/java/com/gogym/gympay/entity/PaymentAmount.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 public class PaymentAmount {
 
+  @Column(nullable = false)
   private Long total;
 
   @Column(name = "tax_free")

--- a/src/main/java/com/gogym/gympay/entity/constant/Currency.java
+++ b/src/main/java/com/gogym/gympay/entity/constant/Currency.java
@@ -1,0 +1,5 @@
+package com.gogym.gympay.entity.constant;
+
+public enum Currency {
+  KRW
+}

--- a/src/main/java/com/gogym/gympay/entity/constant/PaymentMethodType.java
+++ b/src/main/java/com/gogym/gympay/entity/constant/PaymentMethodType.java
@@ -1,0 +1,5 @@
+package com.gogym.gympay.entity.constant;
+
+public enum PaymentMethodType {
+  CARD
+}

--- a/src/main/java/com/gogym/gympay/entity/constant/PgProvider.java
+++ b/src/main/java/com/gogym/gympay/entity/constant/PgProvider.java
@@ -1,0 +1,5 @@
+package com.gogym.gympay.entity.constant;
+
+public enum PgProvider {
+  INICIS
+}

--- a/src/main/java/com/gogym/gympay/entity/constant/SelectedChannelType.java
+++ b/src/main/java/com/gogym/gympay/entity/constant/SelectedChannelType.java
@@ -1,0 +1,5 @@
+package com.gogym.gympay.entity.constant;
+
+public enum SelectedChannelType {
+  TEST
+}

--- a/src/main/java/com/gogym/gympay/entity/constant/Status.java
+++ b/src/main/java/com/gogym/gympay/entity/constant/Status.java
@@ -1,0 +1,7 @@
+package com.gogym.gympay.entity.constant;
+
+public enum Status {
+  PAID,
+  FAILED,
+  CANCELLED
+}

--- a/src/main/java/com/gogym/gympay/entity/constant/WebhookStatus.java
+++ b/src/main/java/com/gogym/gympay/entity/constant/WebhookStatus.java
@@ -1,0 +1,5 @@
+package com.gogym.gympay.entity.constant;
+
+public class WebhookStatus {
+
+}

--- a/src/main/java/com/gogym/gympay/event/PaymentEventListener.java
+++ b/src/main/java/com/gogym/gympay/event/PaymentEventListener.java
@@ -1,0 +1,24 @@
+package com.gogym.gympay.event;
+
+import com.gogym.gympay.service.SSEService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentEventListener {
+
+  private final SSEService sseService;
+
+  @EventListener
+  public void handlePaymentStatusChanged(PaymentStatusChangedEvent event) {
+    switch (event.type()) {
+      case "transaction.paid" ->
+          sseService.sendUpdate(event.paymentId(), "Transaction Paid", null);
+      case "transaction.failed" -> {
+        sseService.sendUpdate(event.paymentId(), "Transaction Failed", event.failureResponse());
+      }
+    }
+  }
+}

--- a/src/main/java/com/gogym/gympay/event/PaymentStatusChangedEvent.java
+++ b/src/main/java/com/gogym/gympay/event/PaymentStatusChangedEvent.java
@@ -1,0 +1,11 @@
+package com.gogym.gympay.event;
+
+import com.gogym.gympay.dto.response.FailureResponse;
+
+public record PaymentStatusChangedEvent(
+    String paymentId,
+    String type,
+    FailureResponse failureResponse
+) {
+
+}

--- a/src/main/java/com/gogym/gympay/repository/GymPayRepository.java
+++ b/src/main/java/com/gogym/gympay/repository/GymPayRepository.java
@@ -1,0 +1,11 @@
+package com.gogym.gympay.repository;
+
+import com.gogym.gympay.entity.GymPay;
+import com.gogym.member.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GymPayRepository extends JpaRepository<GymPay, Long> {
+
+  Optional<GymPay> findByMember(Member member);
+}

--- a/src/main/java/com/gogym/gympay/repository/PaymentRepository.java
+++ b/src/main/java/com/gogym/gympay/repository/PaymentRepository.java
@@ -1,0 +1,10 @@
+package com.gogym.gympay.repository;
+
+import com.gogym.gympay.entity.Payment;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+  Optional<Payment> findByMerchantId(String merchantId);
+}

--- a/src/main/java/com/gogym/gympay/service/GymPayService.java
+++ b/src/main/java/com/gogym/gympay/service/GymPayService.java
@@ -1,0 +1,43 @@
+package com.gogym.gympay.service;
+
+import com.gogym.exception.CustomException;
+import com.gogym.exception.ErrorCode;
+import com.gogym.gympay.entity.GymPay;
+import com.gogym.gympay.repository.GymPayRepository;
+import com.gogym.member.entity.Member;
+import com.gogym.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GymPayService {
+
+  private final MemberService memberService;
+  private final GymPayRepository gymPayRepository;
+
+  @Transactional
+  public Long save(Long memberId) {
+    Member member = memberService.findById(memberId);
+    GymPay gymPay = new GymPay(0, member);
+
+    gymPayRepository.save(gymPay);
+
+    return gymPay.getId();
+  }
+
+  @Transactional
+  public void updateBalance(long memberId, int amount) {
+    Member member = memberService.findById(memberId);
+    GymPay gymPay = getByMember(member);
+
+    gymPay.charge(amount);
+  }
+
+  private GymPay getByMember(Member member) {
+    return gymPayRepository.findByMember(member)
+        .orElseThrow(() -> new CustomException(ErrorCode.GYM_PAY_NOT_FOUND));
+  }
+}

--- a/src/main/java/com/gogym/gympay/service/GymPayService.java
+++ b/src/main/java/com/gogym/gympay/service/GymPayService.java
@@ -1,7 +1,5 @@
 package com.gogym.gympay.service;
 
-import com.gogym.exception.CustomException;
-import com.gogym.exception.ErrorCode;
 import com.gogym.gympay.entity.GymPay;
 import com.gogym.gympay.repository.GymPayRepository;
 import com.gogym.member.entity.Member;
@@ -29,15 +27,9 @@ public class GymPayService {
   }
 
   @Transactional
-  public void updateBalance(long memberId, int amount) {
-    Member member = memberService.findById(memberId);
-    GymPay gymPay = getByMember(member);
+  public void charge(Member member, Long amount) {
+    GymPay gymPay = member.getGymPay();
 
     gymPay.charge(amount);
-  }
-
-  private GymPay getByMember(Member member) {
-    return gymPayRepository.findByMember(member)
-        .orElseThrow(() -> new CustomException(ErrorCode.GYM_PAY_NOT_FOUND));
   }
 }

--- a/src/main/java/com/gogym/gympay/service/PaymentService.java
+++ b/src/main/java/com/gogym/gympay/service/PaymentService.java
@@ -33,6 +33,7 @@ public class PaymentService {
   private final ApplicationEventPublisher eventPublisher;
 
   private final MemberService memberService;
+  private final GymPayService gymPayService;
   private final PortOneService portOneService;
 
   private final PaymentRepository paymentRepository;
@@ -76,7 +77,7 @@ public class PaymentService {
     paymentRepository.save(payment);
 
     if (result.status().equals(Status.PAID))
-    member.getGymPay().charge(result.amount().total());
+    gymPayService.charge(member, result.amount().paid());
 
     publishPaymentStatusChangedEvent(payment.getId(), webhookPayload.type(),
         new FailureResponse(result.failure().reason(), result.failure().pgCode(),

--- a/src/main/java/com/gogym/gympay/service/PaymentService.java
+++ b/src/main/java/com/gogym/gympay/service/PaymentService.java
@@ -1,0 +1,122 @@
+package com.gogym.gympay.service;
+
+import com.gogym.exception.CustomException;
+import com.gogym.exception.ErrorCode;
+import com.gogym.gympay.dto.WebhookPayload;
+import com.gogym.gympay.dto.request.PreRegisterRequest;
+import com.gogym.gympay.dto.response.FailureResponse;
+import com.gogym.gympay.dto.response.PreRegisterResponse;
+import com.gogym.gympay.entity.Payment;
+import com.gogym.gympay.entity.constant.Status;
+import com.gogym.gympay.event.PaymentStatusChangedEvent;
+import com.gogym.gympay.repository.PaymentRepository;
+import com.gogym.member.entity.Member;
+import com.gogym.member.service.MemberService;
+import com.gogym.util.RedisUtil;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Map;
+import java.util.Random;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentService {
+
+  private final RedisUtil redisUtil;
+  private final ApplicationEventPublisher eventPublisher;
+
+  private final MemberService memberService;
+  private final PortOneService portOneService;
+
+  private final PaymentRepository paymentRepository;
+
+  public static final String PAYMENT_ID_PREFIX = "payment:";
+
+  @Transactional
+  public PreRegisterResponse save(Long memberId, PreRegisterRequest request) {
+    String paymentId = generateId();
+
+    portOneService.preRegisterPayment(paymentId, request.amount());
+    redisUtil.saveHash(
+        PAYMENT_ID_PREFIX + paymentId + ":pre-payment",
+        Map.of(
+            "member-id", String.valueOf(memberId),
+            "amount", String.valueOf(request.amount())
+        ),
+        60 * 10
+    );
+
+    return new PreRegisterResponse(paymentId);
+  }
+
+  @Transactional
+  public void processWebhook(WebhookPayload webhookPayload) {
+    if (!webhookPayload.type().equals("Transaction.Paid") &&
+        !webhookPayload.type().equals("Transaction.Failed")) {
+      return;
+    }
+
+    String merchantId = webhookPayload.data().paymentId();
+    var result = portOneService.getPaymentInfo(webhookPayload.data().transactionId());
+
+    Map<Object, Object> prePayment = getPrePaymentData(merchantId);
+    long preAmount = Long.parseLong((String) prePayment.get("amount"));
+    verifyAmount(result.amount().paid(), preAmount);
+
+    Long memberId = Long.parseLong((String) prePayment.get("member-id"));
+    Member member = memberService.findById(memberId);
+    Payment payment = result.toEntity(member);
+    paymentRepository.save(payment);
+
+    if (result.status().equals(Status.PAID))
+    member.getGymPay().charge(result.amount().total());
+
+    publishPaymentStatusChangedEvent(payment.getId(), webhookPayload.type(),
+        new FailureResponse(result.failure().reason(), result.failure().pgCode(),
+            result.failure().message()));
+  }
+
+  private String generateId() {
+    String date = new SimpleDateFormat("yyyyMMdd").format(new Date());
+    Random random = new Random();
+
+    while (true) {
+      int randomNumber = random.nextInt(1000000);
+      String formattedNumber = String.format("%06d", randomNumber);
+
+      boolean isAdded = redisUtil.addToSet(PAYMENT_ID_PREFIX + "ids:" + date, formattedNumber,
+          60 * 60 * 24);
+      if (isAdded) {
+        return date + "-" + formattedNumber;
+      }
+    }
+  }
+
+  private void verifyAmount(long paidAmount, long expectedAmount) {
+    if (paidAmount != expectedAmount) {
+      throw new CustomException(ErrorCode.PAYMENT_MISMATCH);
+    }
+  }
+
+  private Map<Object, Object> getPrePaymentData(String paymentId) {
+    Map<Object, Object> prePayment = redisUtil.getHash(
+        PAYMENT_ID_PREFIX + paymentId + ":pre-payment");
+    if (prePayment == null || prePayment.isEmpty()) {
+      throw new CustomException(ErrorCode.PAYMENT_NOT_FOUND);
+    }
+    return prePayment;
+  }
+
+  private void publishPaymentStatusChangedEvent(String paymentId, String type,
+      FailureResponse failureResponse) {
+    eventPublisher.publishEvent(
+        new PaymentStatusChangedEvent(paymentId, type, failureResponse));
+  }
+}

--- a/src/main/java/com/gogym/gympay/service/PortOneService.java
+++ b/src/main/java/com/gogym/gympay/service/PortOneService.java
@@ -80,9 +80,9 @@ public class PortOneService {
     redisUtil.save(REFRESH_TOKEN_KEY, tokenInfo.refreshToken(), 60 * 60 * 24 * 7);
   }
 
-  public void preRegisterPayment(String merchantUid, int amount) {
+  public void preRegisterPayment(String paymentId, int amount) {
     portOneClient.post()
-        .uri("/payments/" + merchantUid + "/pre-register")
+        .uri("/payments/" + paymentId + "/pre-register")
         .headers(headers -> headers.setBearerAuth(getAccessToken()))
         .bodyValue(Map.of("totalAmount", amount))
         .retrieve()

--- a/src/main/java/com/gogym/gympay/service/PortOneService.java
+++ b/src/main/java/com/gogym/gympay/service/PortOneService.java
@@ -1,0 +1,101 @@
+package com.gogym.gympay.service;
+
+import com.gogym.gympay.dto.PaymentResult;
+import com.gogym.gympay.dto.TokenInfo;
+import com.gogym.util.RedisUtil;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@Transactional(readOnly = true)
+public class PortOneService {
+
+  private final WebClient portOneClient;
+  private final RedisUtil redisUtil;
+
+  @Value("${port-one.secret}")
+  private String secretKey;
+
+  public static final String ACCESS_TOKEN_KEY = "portone:access-token";
+  public static final String REFRESH_TOKEN_KEY = "portone:refresh-token";
+
+  public PortOneService(@Qualifier("portOneClient") WebClient portOneClient, RedisUtil redisUtil) {
+    this.portOneClient = portOneClient;
+    this.redisUtil = redisUtil;
+  }
+
+  public String getAccessToken() {
+    String accessToken = redisUtil.get(ACCESS_TOKEN_KEY);
+
+    if (accessToken != null && !accessToken.isEmpty()) {
+      return accessToken;
+    }
+
+    return refreshAccessToken();
+  }
+
+  private String refreshAccessToken() {
+    String refreshToken = redisUtil.get(REFRESH_TOKEN_KEY);
+
+    if (refreshToken == null || refreshToken.isEmpty()) {
+      return signIn();
+    }
+
+    try {
+      TokenInfo tokenInfo = portOneClient.post()
+          .uri("/token/refresh")
+          .bodyValue(Map.of("refreshToken", refreshToken))
+          .retrieve()
+          .bodyToMono(TokenInfo.class)
+          .block();
+
+      storeTokens(tokenInfo);
+
+      return tokenInfo.accessToken();
+    } catch (Exception e) {
+      return signIn();
+    }
+  }
+
+  private String signIn() {
+    TokenInfo tokenInfo = portOneClient.post()
+        .uri("/login/api-secret")
+        .bodyValue(Map.of("apiSecret", secretKey))
+        .retrieve()
+        .bodyToMono(TokenInfo.class)
+        .block();
+
+    storeTokens(tokenInfo);
+
+    return tokenInfo.accessToken();
+  }
+
+  private void storeTokens(TokenInfo tokenInfo) {
+
+    redisUtil.save(ACCESS_TOKEN_KEY, tokenInfo.accessToken(), 60 * 60 * 24);
+    redisUtil.save(REFRESH_TOKEN_KEY, tokenInfo.refreshToken(), 60 * 60 * 24 * 7);
+  }
+
+  public void preRegisterPayment(String merchantUid, int amount) {
+    portOneClient.post()
+        .uri("/payments/" + merchantUid + "/pre-register")
+        .headers(headers -> headers.setBearerAuth(getAccessToken()))
+        .bodyValue(Map.of("totalAmount", amount))
+        .retrieve()
+        .bodyToMono(Void.class)
+        .block();
+  }
+
+  public PaymentResult getPaymentInfo(String transactionId) {
+    return portOneClient.get()
+        .uri("/payments/" + transactionId)
+        .headers(headers -> headers.setBearerAuth("PortOne " + secretKey))
+        .retrieve()
+        .bodyToMono(PaymentResult.class)
+        .block();
+  }
+}

--- a/src/main/java/com/gogym/gympay/service/SSEService.java
+++ b/src/main/java/com/gogym/gympay/service/SSEService.java
@@ -14,24 +14,24 @@ public class SSEService {
 
   private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 
-  public SseEmitter subscribe(String merchantUid) {
+  public SseEmitter subscribe(String paymentId) {
     SseEmitter emitter = new SseEmitter(60 * 1000L);
-    emitters.put(merchantUid, emitter);
-    emitter.onCompletion(() -> emitters.remove(merchantUid));
-    emitter.onTimeout(() -> emitters.remove(merchantUid));
+    emitters.put(paymentId, emitter);
+    emitter.onCompletion(() -> emitters.remove(paymentId));
+    emitter.onTimeout(() -> emitters.remove(paymentId));
 
     return emitter;
   }
 
-  public void sendUpdate(String merchantId, String eventName, FailureResponse response) {
-    if (!emitters.containsKey(merchantId)) {
+  public void sendUpdate(String paymentId, String eventName, FailureResponse response) {
+    if (!emitters.containsKey(paymentId)) {
       throw new CustomException(ErrorCode.SSE_SUBSCRIPTION_NOT_FOUND);
     }
 
-    SseEmitter emitter = emitters.get(merchantId);
+    SseEmitter emitter = emitters.get(paymentId);
     try {
       SseEmitter.SseEventBuilder eventBuilder = SseEmitter.event()
-          .id(merchantId)
+          .id(paymentId)
           .name(eventName)
           .reconnectTime(3000);
 

--- a/src/main/java/com/gogym/gympay/service/SSEService.java
+++ b/src/main/java/com/gogym/gympay/service/SSEService.java
@@ -1,0 +1,47 @@
+package com.gogym.gympay.service;
+
+import com.gogym.exception.CustomException;
+import com.gogym.exception.ErrorCode;
+import com.gogym.gympay.dto.response.FailureResponse;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+public class SSEService {
+
+  private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+  public SseEmitter subscribe(String merchantUid) {
+    SseEmitter emitter = new SseEmitter(60 * 1000L);
+    emitters.put(merchantUid, emitter);
+    emitter.onCompletion(() -> emitters.remove(merchantUid));
+    emitter.onTimeout(() -> emitters.remove(merchantUid));
+
+    return emitter;
+  }
+
+  public void sendUpdate(String merchantId, String eventName, FailureResponse response) {
+    if (!emitters.containsKey(merchantId)) {
+      throw new CustomException(ErrorCode.SSE_SUBSCRIPTION_NOT_FOUND);
+    }
+
+    SseEmitter emitter = emitters.get(merchantId);
+    try {
+      SseEmitter.SseEventBuilder eventBuilder = SseEmitter.event()
+          .id(merchantId)
+          .name(eventName)
+          .reconnectTime(3000);
+
+      if (response != null) {
+        eventBuilder.data(response);
+      }
+
+      emitter.send(eventBuilder.build());
+    } catch (IOException e) {
+      throw new CustomException(ErrorCode.SSE_SEND_ERROR);
+    }
+  }
+}

--- a/src/main/java/com/gogym/member/entity/Member.java
+++ b/src/main/java/com/gogym/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.gogym.member.entity;
 
 import com.gogym.common.entity.BaseEntity;
+import com.gogym.gympay.entity.GymPay;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -50,6 +51,10 @@ public class Member extends BaseEntity {
   @Setter
   @Column(name = "verified_at")
   private LocalDateTime verifiedAt; // 이메일 인증 시간을 저장
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "gym_pay_id")
+  private GymPay gymPay;
 
   // 이메일 인증 여부 확인 메서드
   public boolean isVerified() {

--- a/src/main/java/com/gogym/util/RedisUtil.java
+++ b/src/main/java/com/gogym/util/RedisUtil.java
@@ -2,9 +2,10 @@ package com.gogym.util;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
-import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
@@ -47,4 +48,12 @@ public class RedisUtil {
     }
   }
 
+  public void saveHash(String key, Map<String, String> data, long ttl) {
+    redisTemplate.opsForHash().putAll(key, data);
+    redisTemplate.expire(key, Duration.ofSeconds(ttl));
+  }
+
+  public Map<Object, Object> getHash(String key) {
+    return redisTemplate.opsForHash().entries(key);
+  }
 }


### PR DESCRIPTION
### ## ⚡️ Issue 번호
#7 
<!--
키워드: close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved
예시: close #10 !-->

## 🛠️ 작업 내용 (What)
짐페이 잔액 충전, 포트원 결제 기능을 구현했습니다. 

결제 흐름은 아래와 같습니다.
1. **클라이언트** 사용자가 금액과 함께 잔액 충전 요청하기
2. **클라이언트 -> 서버** 결제 정보 사전 등록 api, SSE 구독 api 호출
3. **서버 -> 포트원** 결제 정보 사전 등록
4. **클라이언트** 사용자가 결제 진행
5. 결제 완료 시 포트원 -> 서버 웹훅 전송
6. 서버에서 웹훅 검증 후 SSE 전송

## 📌 작업 이유 (Why)

## ✨ 변경 사항 (Changes)
- PortOne 토큰 발급, 재발급 기능
- 결제 정보 사전 등록 기능
- 결제 후 검증 로직(웹훅 시그니처, 결제 정보 금액과 실 결제 금액 일치 여부) 

## ✅ 테스트 (Tests)
결제 후 받을 수 있는 정보를 더미로만 확인하다 보니 아직 dto나 로직이 수정이 필요해서 테스트코드 작성 전입니다. 추후 추가 예정입니다!

## 💬 리뷰 포인트 (Review Points)
