### PR TITLE
✨️feat : WebSocket 초기 연결 시 JWT 인증 로직 구현

### DIFF
--- a/src/main/java/com/gogym/aop/LoggingAspect.java
+++ b/src/main/java/com/gogym/aop/LoggingAspect.java
@@ -27,7 +27,7 @@ public class LoggingAspect {
   public void apiLayer() {
   }
 
-  @Pointcut("execution(* com.gogym..service..*(..)) && !execution(* com.gogym..schedule..*(..)) && !execution(* com.gogym.notification.service.NotificationService.getEmitters(..))")
+  @Pointcut("execution(* com.gogym..service..*(..)) && !execution(* com.gogym..schedule..*(..))")
   public void serviceLayer() {
   }
 

--- a/src/main/java/com/gogym/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/gogym/chat/controller/ChatRoomController.java
@@ -1,6 +1,6 @@
 package com.gogym.chat.controller;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -48,10 +48,10 @@ public class ChatRoomController {
    * @param memberId 요청자 ID
    * @param page 조회할 페이지 번호
    * @param size 페이지당 항목 수
-   * @return {@link ChatroomResponse} 객체 리스트를 포함한 {@link ResponseEntity}.
+   * @return {@link ChatroomResponse} 객체 리스트를 포함한 {@link Page}.
    */
   @GetMapping
-  public ResponseEntity<List<ChatRoomResponse>> getChatRooms(
+  public ResponseEntity<Page<ChatRoomResponse>> getChatRooms(
       @LoginMemberId Long memberId,
       @RequestParam("page") int page,
       @RequestParam("size") int size) {

--- a/src/main/java/com/gogym/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/gogym/chat/controller/ChatRoomController.java
@@ -1,6 +1,7 @@
 package com.gogym.chat.controller;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,7 +9,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import com.gogym.chat.dto.ChatRoomDto.ChatRoomResponse;
 import com.gogym.chat.dto.ChatRoomDto.LeaveRequest;
@@ -53,9 +53,8 @@ public class ChatRoomController {
   @GetMapping
   public ResponseEntity<Page<ChatRoomResponse>> getChatRooms(
       @LoginMemberId Long memberId,
-      @RequestParam("page") int page,
-      @RequestParam("size") int size) {
-    return ResponseEntity.ok(this.chatRoomService.getChatRooms(memberId, page, size));
+      Pageable pageable) {
+    return ResponseEntity.ok(this.chatRoomService.getChatRooms(memberId, pageable));
   }
   
   /**

--- a/src/main/java/com/gogym/chat/controller/WebSocketChatController.java
+++ b/src/main/java/com/gogym/chat/controller/WebSocketChatController.java
@@ -1,11 +1,18 @@
 package com.gogym.chat.controller;
 
+import java.security.Principal;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import com.gogym.chat.dto.ChatMessageDto.ChatMessageRequest;
 import com.gogym.chat.dto.ChatMessageDto.ChatMessageResponse;
 import com.gogym.chat.service.ChatRedisService;
+import com.gogym.chat.service.ChatRoomService;
+import com.gogym.exception.CustomException;
+import com.gogym.exception.ErrorCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -16,10 +23,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WebSocketChatController {
   
-  private static final String TOPIC_CHATROOM_PREFIX = "/topic/chatroom/";
-  
   private final SimpMessagingTemplate messagingTemplate;
   private final ChatRedisService chatRedisService;
+  private final ChatRoomService chatRoomService;
+  
+  private static final String TOPIC_CHATROOM_PREFIX = "/topic/chatroom/";
   
   /**
    * 실시간 채팅 메시지를 처리하고 Redis에 저장한 뒤,
@@ -27,14 +35,34 @@ public class WebSocketChatController {
    * 
    * 클라이언트는 "/app/chatroom/message" 경로로 메시지를 보냅니다.
    * 
-   * @param request 송신 메시지 정보를 포함한 {@link ChatMessageRequest}.
+   * @param messageRequest 클라이언트가 전송한 채팅 메시지 요청 데이터
+   * @param headerAccessor STOMP 메시지 헤더에 접근하기 위한 접근자
    */
+  @CrossOrigin
   @MessageMapping("/chatroom/message")
-  public void send(@Valid ChatMessageRequest messageRequest) {
-    // 메시지를 Redis에 저장
-    ChatMessageResponse savedMessage = this.chatRedisService.saveMessageToRedis(messageRequest);
+  public void send(
+      @Valid @Payload ChatMessageRequest messageRequest,
+      SimpMessageHeaderAccessor headerAccessor) {
+    // STOMP 세션에서 인증된 사용자 정보(Principal) 가져오기
+    Principal principal = (Principal) headerAccessor.getSessionAttributes().get("principal");
     
-    // 메시지를 구독자에게 전송
+    // 사용자 인증이 세션에 유지되고 있는지를 확인하기 위한 방어 로직
+    if (principal == null) {
+      throw new CustomException(ErrorCode.UNAUTHORIZED);
+    }
+    
+    // 사용자 ID 추출
+    Long memberId = Long.valueOf(principal.getName());
+    
+    // 사용자가 채팅방에 속해있는지 확인하기 위한 방어 로직
+    if (!this.chatRoomService.isMemberInChatRoom(messageRequest.chatRoomId(), memberId)) {
+      throw new CustomException(ErrorCode.FORBIDDEN);
+    }
+    
+    // 메시지를 Redis에 저장
+    ChatMessageResponse savedMessage = this.chatRedisService.saveMessageToRedis(messageRequest, memberId);
+    
+    // 메시지 브로드캐스트
     this.messagingTemplate.convertAndSend(
         TOPIC_CHATROOM_PREFIX + messageRequest.chatRoomId(),
         savedMessage);

--- a/src/main/java/com/gogym/chat/controller/WebSocketChatController.java
+++ b/src/main/java/com/gogym/chat/controller/WebSocketChatController.java
@@ -48,7 +48,7 @@ public class WebSocketChatController {
     
     // 사용자 인증이 세션에 유지되고 있는지를 확인하기 위한 방어 로직
     if (principal == null) {
-      throw new CustomException(ErrorCode.UNAUTHORIZED);
+      throw new CustomException(ErrorCode.WEBSOCKET_UNAUTHORIZED);
     }
     
     // 사용자 ID 추출

--- a/src/main/java/com/gogym/chat/controller/WebSocketChatController.java
+++ b/src/main/java/com/gogym/chat/controller/WebSocketChatController.java
@@ -1,6 +1,7 @@
 package com.gogym.chat.controller;
 
 import java.security.Principal;
+import java.util.UUID;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
@@ -15,10 +16,12 @@ import com.gogym.exception.CustomException;
 import com.gogym.exception.ErrorCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * WebSocket을 통한 실시간 채팅 메시지 처리를 담당하는 컨트롤러.
  */
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 public class WebSocketChatController {
@@ -61,6 +64,16 @@ public class WebSocketChatController {
     
     // 메시지를 Redis에 저장
     ChatMessageResponse savedMessage = this.chatRedisService.saveMessageToRedis(messageRequest, memberId);
+    
+    // 고유 트랜잭션 ID 추출
+    String transactionId = UUID.randomUUID().toString().substring(0, 8);
+    
+    // WebSocket 로깅
+    log.info("[WebSocket] TransactionId: {}, SenderId: {}, ChatRoomId: {}, Content: {}",
+        transactionId,
+        memberId,
+        savedMessage.chatRoomId(),
+        savedMessage.content());
     
     // 메시지 브로드캐스트
     this.messagingTemplate.convertAndSend(

--- a/src/main/java/com/gogym/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/gogym/chat/dto/ChatMessageDto.java
@@ -19,6 +19,6 @@ public class ChatMessageDto {
   public record ChatMessageHistory(
       String content,
       Long senderId,
-      String createdAt) {}
+      LocalDateTime createdAt) {}
 
 }

--- a/src/main/java/com/gogym/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/gogym/chat/dto/ChatMessageDto.java
@@ -8,7 +8,6 @@ public class ChatMessageDto {
 
   public record ChatMessageRequest(
       @NotNull Long chatRoomId,
-      @NotNull Long senderId,
       @NotBlank String content) {}
 
   public record ChatMessageResponse(

--- a/src/main/java/com/gogym/chat/dto/ChatRoomDto.java
+++ b/src/main/java/com/gogym/chat/dto/ChatRoomDto.java
@@ -13,7 +13,9 @@ public class ChatRoomDto {
       String counterpartyNickname,
       int unreadMessageCount,
       String lastMessage,
-      LocalDateTime lastMessageAt) {}
+      LocalDateTime lastMessageAt,
+      boolean postAuthorActive,
+      boolean requestorActive) {}
 
   public record LeaveRequest(@NotNull Long lastReadMessageId) {}
 

--- a/src/main/java/com/gogym/chat/entity/ChatRoom.java
+++ b/src/main/java/com/gogym/chat/entity/ChatRoom.java
@@ -24,11 +24,11 @@ import lombok.Setter;
 @Builder
 public class ChatRoom extends BaseEntity {
   
-  @JoinColumn(name = "post", nullable = false)
+  @JoinColumn(name = "post_id", nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
   private Post post; // 게시글 작성자
   
-  @JoinColumn(name = "requestor", nullable = false)
+  @JoinColumn(name = "requestor_id", nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
   private Member requestor; // 채팅 요청자
   

--- a/src/main/java/com/gogym/chat/entity/ChatRoom.java
+++ b/src/main/java/com/gogym/chat/entity/ChatRoom.java
@@ -24,11 +24,11 @@ import lombok.Setter;
 @Builder
 public class ChatRoom extends BaseEntity {
   
-  @JoinColumn(name = "post_id", nullable = false)
+  @JoinColumn(name = "post", nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
   private Post post; // 게시글 작성자
   
-  @JoinColumn(name = "request_id", nullable = false)
+  @JoinColumn(name = "requestor", nullable = false)
   @ManyToOne(fetch = FetchType.LAZY)
   private Member requestor; // 채팅 요청자
   

--- a/src/main/java/com/gogym/chat/handler/StompHandler.java
+++ b/src/main/java/com/gogym/chat/handler/StompHandler.java
@@ -1,0 +1,69 @@
+package com.gogym.chat.handler;
+
+import java.security.Principal;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+import com.gogym.exception.CustomException;
+import com.gogym.exception.ErrorCode;
+import com.gogym.member.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * STOMP 메시지의 전처리를 담당하는 핸들러.
+ * WebSocket 연결 시 JWT 토큰을 검증하고 사용자 정보를 세션에 저장합니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class StompHandler implements ChannelInterceptor {
+  
+  private final JwtTokenProvider jwtTokenProvider;
+  
+  /**
+   * STOMP 메시지를 전처리하는 메서드.
+   * 
+   * @param message 클라이언트가 전송한 메시지
+   * @param channel 메시지가 전달될 채널
+   * @return 처리된 메시지
+   */
+  @Override
+  public Message<?> preSend(Message<?> message, MessageChannel channel) {
+    // STOMP 메시지 헤더 접근자 생성
+    StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+    
+    // STOMP 메시지 명령이 CONNECT인 경우 -> WebSocket 초기 연결
+    if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+      String token = accessor.getFirstNativeHeader("Authorization");
+      
+      // JWT가 존재하고 "Bearer "로 시작하는 경우에만 처리
+      if (token != null && token.startsWith("Bearer ")) {
+        token = token.substring(7); // "Bearer " 제거
+        
+        // JWT 유효성 검증
+        if (this.jwtTokenProvider.validateToken(token)) {
+          // 사용자 ID 추출
+          Long memberId = this.jwtTokenProvider.extractMemberId(token);
+          
+          // 인증된 사용자 정보를 나타내는 Principal 객체 생성
+          Principal principal = () -> String.valueOf(memberId);
+          
+          // STOMP 세션에 Principal 저장
+          accessor.getSessionAttributes().put("principal", principal);
+          
+          // STOMP 메시지의 사용자 정보 설정
+          accessor.setUser(principal);
+        } else {
+          throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
+      } else {
+        throw new CustomException(ErrorCode.INVALID_TOKEN);
+      }
+    }
+    
+    return message;
+  }
+
+}

--- a/src/main/java/com/gogym/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/gogym/chat/repository/ChatRoomRepository.java
@@ -31,7 +31,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
       SELECT cr
       FROM ChatRoom cr
       LEFT JOIN ChatMessage cm ON cm.chatRoom.id = cr.id
-      WHERE (cr.postId = :postAuthorId OR cr.requestorId = :requestorId)
+      WHERE (cr.post.id = :postAuthorId OR cr.requestor.id = :requestorId)
         AND cr.isDeleted = false
       GROUP BY cr.id
       ORDER BY MAX(cm.createdAt) DESC
@@ -51,5 +51,27 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
    * @return 특정 채팅방 (Optional)
    */
   Optional<ChatRoom> findByIdAndPostMemberIdOrRequestorId(Long chatRoomId, Long postAuthorId, Long requestorId);
+  
+  
+  /**
+   * 특정 사용자가 특정 채팅방에 참여 중인지 확인.
+   *
+   * @param chatRoomId 확인할 채팅방 ID
+   * @param memberId 확인할 사용자 ID
+   * @return true: 사용자가 해당 채팅방에 참여 중인 경우, false: 참여하지 않은 경우
+   */
+  @Query("""
+      SELECT EXISTS (
+          SELECT 1
+          FROM ChatRoom cr
+          WHERE cr.id = :chatRoomId
+            AND (cr.post.member.id = :memberId OR cr.requestor.id = :memberId)
+            AND cr.isDeleted = false
+      )
+  """)
+  boolean existsByChatRoomIdAndMemberId(
+      @Param("chatRoomId") Long chatRoomId,
+      @Param("memberId") Long memberId
+  );
   
 }

--- a/src/main/java/com/gogym/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/gogym/chat/repository/ChatRoomRepository.java
@@ -31,7 +31,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
       SELECT cr
       FROM ChatRoom cr
       LEFT JOIN ChatMessage cm ON cm.chatRoom.id = cr.id
-      WHERE (cr.post.id = :postAuthorId OR cr.requestor.id = :requestorId)
+      WHERE (cr.post.member.id = :postAuthorId OR cr.requestor.id = :requestorId)
         AND cr.isDeleted = false
       GROUP BY cr.id
       ORDER BY MAX(cm.createdAt) DESC
@@ -50,8 +50,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
    * @param requestorId 요청자 ID
    * @return 특정 채팅방 (Optional)
    */
-  Optional<ChatRoom> findByIdAndPostMemberIdOrRequestorId(Long chatRoomId, Long postAuthorId, Long requestorId);
-  
+  Optional<ChatRoom> findByIdAndPost_MemberIdOrRequestor_Id(Long chatRoomId, Long postAuthorId, Long requestorId);
   
   /**
    * 특정 사용자가 특정 채팅방에 참여 중인지 확인.

--- a/src/main/java/com/gogym/chat/service/ChatRedisService.java
+++ b/src/main/java/com/gogym/chat/service/ChatRedisService.java
@@ -10,9 +10,10 @@ public interface ChatRedisService {
    * 메시지를 Redis에 저장 후 응답
    * 
    * @param messageRequest 요청 메시지
+   * @param memberId 메시지를 보낸 사용자 ID
    * @return 저장된 메시지 응답
    */
-  ChatMessageResponse saveMessageToRedis(ChatMessageRequest messageRequest);
+  ChatMessageResponse saveMessageToRedis(ChatMessageRequest messageRequest, Long memberId);
   
   /**
    * Redis에서 특정 채팅방의 메시지 목록을 조회

--- a/src/main/java/com/gogym/chat/service/ChatRoomService.java
+++ b/src/main/java/com/gogym/chat/service/ChatRoomService.java
@@ -42,4 +42,13 @@ public interface ChatRoomService {
    */
   void deleteChatRoom(Long memberId, Long chatRoomId);
   
+  /**
+   * 사용자가 특정 채팅방에 참여 중인지 확인
+   * 
+   * @param chatRoomId 확인할 채팅방 ID
+   * @param memberId 확인할 사용자 ID
+   * @return true: 사용자가 해당 채팅방에 참여 중인 경우, false: 참여하지 않은 경우
+   */
+  boolean isMemberInChatRoom(Long chatRoomId, Long memberId);
+  
 }

--- a/src/main/java/com/gogym/chat/service/ChatRoomService.java
+++ b/src/main/java/com/gogym/chat/service/ChatRoomService.java
@@ -1,6 +1,6 @@
 package com.gogym.chat.service;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
 import com.gogym.chat.dto.ChatRoomDto.ChatRoomResponse;
 import com.gogym.chat.dto.ChatRoomDto.LeaveRequest;
 
@@ -23,7 +23,7 @@ public interface ChatRoomService {
    * @param size 페이지당 항목 수
    * @return 사용자가 참여한 채팅 목록
    */
-  List<ChatRoomResponse> getChatRooms(Long memberId, int page, int size);
+  Page<ChatRoomResponse> getChatRooms(Long memberId, int page, int size);
   
   /**
    * 채팅방 나가기

--- a/src/main/java/com/gogym/chat/service/ChatRoomService.java
+++ b/src/main/java/com/gogym/chat/service/ChatRoomService.java
@@ -1,6 +1,7 @@
 package com.gogym.chat.service;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import com.gogym.chat.dto.ChatRoomDto.ChatRoomResponse;
 import com.gogym.chat.dto.ChatRoomDto.LeaveRequest;
 
@@ -19,11 +20,10 @@ public interface ChatRoomService {
    * 사용자가 참여한 채팅방 목록 조회
    * 
    * @param memberId 요청자 ID
-   * @param page 페이지 번호
-   * @param size 페이지당 항목 수
+   * @param pageable 페이징 정보
    * @return 사용자가 참여한 채팅 목록
    */
-  Page<ChatRoomResponse> getChatRooms(Long memberId, int page, int size);
+  Page<ChatRoomResponse> getChatRooms(Long memberId, Pageable pageable);
   
   /**
    * 채팅방 나가기

--- a/src/main/java/com/gogym/chat/service/impl/ChatRedisServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRedisServiceImpl.java
@@ -24,7 +24,7 @@ public class ChatRedisServiceImpl implements ChatRedisService {
   private final RedisUtil redisUtil;
 
   @Override
-  public ChatMessageResponse saveMessageToRedis(ChatMessageRequest messageRequest) {
+  public ChatMessageResponse saveMessageToRedis(ChatMessageRequest messageRequest, Long memberId) {
     // Redis Key 생성
     String redisKey = this.getRedisChatroomMessageKeyPrefix() + messageRequest.chatRoomId();
 
@@ -34,7 +34,7 @@ public class ChatRedisServiceImpl implements ChatRedisService {
     // Redis에 저장할 메시지 객체 생성
     ChatMessageHistory messageHistory = new ChatMessageHistory(
         messageRequest.content(),
-        messageRequest.senderId(),
+        memberId,
         createdAt);
 
     // 메시지 객체를 JSON 문자열로 직렬화
@@ -46,7 +46,7 @@ public class ChatRedisServiceImpl implements ChatRedisService {
     // 메시지 저장 결과 반환
     return new ChatMessageResponse(
         messageRequest.chatRoomId(),
-        messageRequest.senderId(),
+        memberId,
         messageRequest.content(),
         LocalDateTime.parse(createdAt, DATE_TIME_FORMATTER));
   }

--- a/src/main/java/com/gogym/chat/service/impl/ChatRedisServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRedisServiceImpl.java
@@ -1,7 +1,6 @@
 package com.gogym.chat.service.impl;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,19 +16,18 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ChatRedisServiceImpl implements ChatRedisService {
-
-  private final String REDIS_CHATROOM_MESSAGE_KEY = "chatroom:messages:";
-  private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
+  
   private final RedisUtil redisUtil;
-
+  
+  private final String REDIS_CHATROOM_MESSAGE_KEY = "chatroom:messages:";
+  
   @Override
   public ChatMessageResponse saveMessageToRedis(ChatMessageRequest messageRequest, Long memberId) {
     // Redis Key 생성
     String redisKey = this.getRedisChatroomMessageKeyPrefix() + messageRequest.chatRoomId();
 
     // LocalDateTime을 String으로 변환
-    String createdAt = LocalDateTime.now().format(DATE_TIME_FORMATTER);
+    LocalDateTime createdAt = LocalDateTime.now();
 
     // Redis에 저장할 메시지 객체 생성
     ChatMessageHistory messageHistory = new ChatMessageHistory(
@@ -48,7 +46,7 @@ public class ChatRedisServiceImpl implements ChatRedisService {
         messageRequest.chatRoomId(),
         memberId,
         messageRequest.content(),
-        LocalDateTime.parse(createdAt, DATE_TIME_FORMATTER));
+        createdAt);
   }
   
   @Override

--- a/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
@@ -66,7 +66,10 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         postAuthor.getNickname(), // counterpartyNickname
         0, // unreadMessageCount
         null, // lastMessage
-        null); // lastMessageAt
+        null,// lastMessageAt
+        newChatRoom.getPostAuthorActive(), // postAuthorActive
+        newChatRoom.getRequestorActive() // requestorActive
+    );
   }
   
   @Override
@@ -140,7 +143,10 @@ public class ChatRoomServiceImpl implements ChatRoomService {
           counterparty.getNickname(), // counterpartyNickname
           unreadMessageCount, // unreadMessageCount
           lastMessage != null ? lastMessage.getContent() : null, // lastMessage
-          lastMessageAt); // lastMessageAt
+          lastMessageAt, // lastMessageAt
+          chatRoom.getPostAuthorActive(), // postAuthorActive
+          chatRoom.getRequestorActive() // requestorActive
+      );
     });
   }
   

--- a/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
@@ -1,7 +1,6 @@
 package com.gogym.chat.service.impl;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
@@ -110,11 +109,9 @@ public class ChatRoomServiceImpl implements ChatRoomService {
               .senderId(lastMessageHistory.senderId())
               .chatRoom(chatRoom)
               .build();
-
+          
           // 메시지 생성 시간 설정
-          lastMessageAt = LocalDateTime.parse(
-              lastMessageHistory.createdAt(),
-              DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+          lastMessageAt = lastMessageHistory.createdAt();
         }
       }
 

--- a/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
@@ -5,7 +5,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import com.gogym.chat.dto.ChatMessageDto.ChatMessageHistory;
 import com.gogym.chat.dto.ChatRoomDto.ChatRoomResponse;
@@ -70,12 +70,12 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   }
   
   @Override
-  public Page<ChatRoomResponse> getChatRooms(Long memberId, int page, int size) {
+  public Page<ChatRoomResponse> getChatRooms(Long memberId, Pageable pageable) {
     // 페이징 조건으로 사용자가 참여한 채팅방 목록 조회
     Page<ChatRoom> chatRooms = this.chatRoomRepository.findChatRoomsSortedByLastMessage(
         memberId,
         memberId,
-        PageRequest.of(page, size));
+        pageable);
     
     // 채팅방 목록 데이터 반환
     return chatRooms.map(chatRoom -> {

--- a/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
@@ -70,7 +70,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
   }
   
   @Override
-  public List<ChatRoomResponse> getChatRooms(Long memberId, int page, int size) {
+  public Page<ChatRoomResponse> getChatRooms(Long memberId, int page, int size) {
     // 페이징 조건으로 사용자가 참여한 채팅방 목록 조회
     Page<ChatRoom> chatRooms = this.chatRoomRepository.findChatRoomsSortedByLastMessage(
         memberId,
@@ -78,7 +78,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
         PageRequest.of(page, size));
     
     // 채팅방 목록 데이터 반환
-    return chatRooms.stream().map(chatRoom -> {
+    return chatRooms.map(chatRoom -> {
       // 상대방 정보 조회
       Member counterparty = chatRoom.getRequestor().getId().equals(memberId)
           ? chatRoom.getPost().getMember() // 게시글 작성자가 상대방인 경우
@@ -141,7 +141,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
           unreadMessageCount, // unreadMessageCount
           lastMessage != null ? lastMessage.getContent() : null, // lastMessage
           lastMessageAt); // lastMessageAt
-    }).collect(Collectors.toList());
+    });
   }
   
   @Override

--- a/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
@@ -214,6 +214,11 @@ public class ChatRoomServiceImpl implements ChatRoomService {
     }
   }
   
+  @Override
+  public boolean isMemberInChatRoom(Long chatRoomId, Long memberId) {
+    return this.chatRoomRepository.existsByChatRoomIdAndMemberId(chatRoomId, memberId);
+  }
+  
   /**
    * Redis에 저장된 메시지들을 강제로 DB에 저장.
    * 

--- a/src/main/java/com/gogym/config/SecurityConfig.java
+++ b/src/main/java/com/gogym/config/SecurityConfig.java
@@ -44,7 +44,8 @@ public class SecurityConfig {
             .requestMatchers("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
                 "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
                 "/api/auth/send-verification-email", "/api/regions",
-                "api/posts/views", "api/posts/filters", "api/posts/details/*", "/api/payments/webhook")
+                "api/posts/views", "api/posts/filters", "api/posts/details/*", "/api/payments/webhook",
+                "/ws/**")
             .permitAll()
             // 그 외의 모든 요청은 인증 필요
             .anyRequest().authenticated())
@@ -65,7 +66,8 @@ public class SecurityConfig {
     return List.of("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
         "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
         "/api/auth/send-verification-email", "/api/regions",
-        "api/posts/views", "api/posts/filters", "api/posts/details/*", "/api/payments/webhook"
+        "api/posts/views", "api/posts/filters", "api/posts/details/*", "/api/payments/webhook",
+        "/ws/**"
     );
   }
 }

--- a/src/main/java/com/gogym/config/SecurityConfig.java
+++ b/src/main/java/com/gogym/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
                 "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
                 "/api/auth/send-verification-email", "/api/regions",
                 "api/posts/views", "api/posts/filters", "api/posts/details/*", "/api/payments/webhook",
+                "api/payments/sse/subscribe/**", "api/images",
                 "/ws/**")
             .permitAll()
             // 그 외의 모든 요청은 인증 필요
@@ -67,6 +68,7 @@ public class SecurityConfig {
         "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
         "/api/auth/send-verification-email", "/api/regions",
         "api/posts/views", "api/posts/filters", "api/posts/details/*", "/api/payments/webhook",
+        "api/payments/sse/subscribe/**", "api/images",
         "/ws/**"
     );
   }

--- a/src/main/java/com/gogym/config/WebSocketConfig.java
+++ b/src/main/java/com/gogym/config/WebSocketConfig.java
@@ -1,27 +1,45 @@
 package com.gogym.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import com.gogym.chat.handler.StompHandler;
+import lombok.RequiredArgsConstructor;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
   
+  private final StompHandler stompHandler;
+  
   @Override
   public void configureMessageBroker(MessageBrokerRegistry config) {
-    // 클라이언트가 메시지를 받을 경로(prefix)
-    config.enableSimpleBroker("/topic", "/queue");
-    // 클라이언트가 메시지를 보낼 경로(prefix)
-    config.setApplicationDestinationPrefixes("/app");
+    // 메시지 브로커 설정
+    config.enableSimpleBroker("/topic", "/queue"); // 클라이언트 구독 경로
+    config.setApplicationDestinationPrefixes("/app"); // 클라이언트 송신 경로
   }
   
   @Override
   public void registerStompEndpoints(StompEndpointRegistry registry) {
-    // WebSocket 연결 endpoint 설정(SockJS 사용)
-    registry.addEndpoint("/ws").setAllowedOriginPatterns("https://gogym-eight.vercel.app/").withSockJS();
+    registry
+        .addEndpoint("/ws") // WebSocket 연결 엔드포인트
+        .setAllowedOriginPatterns( // Origin 허용 설정
+            "http://localhost:8080", // 테스트 환경
+            "http://localhost:3000", // 로컬 클라이언트 환경
+            "http://localhost:3001", // 로컬 클라이언트 환경
+            "https://gogym-eight.vercel.app/" // 배포 클라이언트 환경
+        )
+        .withSockJS(); // 브라우저 호환성을 위한 SockJS 라이브러리 지원
+  }
+  
+  @Override
+  public void configureClientInboundChannel(ChannelRegistration registration) {
+    // STOMP 메시지 처리에 StompChannelInterceptor 등록
+    registration.interceptors(this.stompHandler);
   }
   
 }

--- a/src/main/java/com/gogym/member/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gogym/member/jwt/JwtAuthenticationFilter.java
@@ -22,6 +22,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) {
     String path = request.getRequestURI();
+    
+    // WebSocket 초기 연결 요청 시에는 Interceptor에서 확인
+    if (path.startsWith("/ws")) {
+      return true;
+    }
+    
     // 인증이 필요 없는 경로 확인
     return exemptUrls.contains(path);
   }

--- a/src/test/java/com/gogym/chat/service/impl/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/gogym/chat/service/impl/ChatRoomServiceImplTest.java
@@ -22,6 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import com.gogym.chat.dto.ChatRoomDto.ChatRoomResponse;
 import com.gogym.chat.dto.ChatRoomDto.LeaveRequest;
@@ -166,7 +167,7 @@ class ChatRoomServiceImplTest {
     when(this.chatMessageReadRepository.countUnreadMessages(eq(chatRoomId), eq(memberId))).thenReturn(5);
 
     // When
-    Page<ChatRoomResponse> responses = this.chatRoomService.getChatRooms(memberId, 0, 10);
+    Page<ChatRoomResponse> responses = this.chatRoomService.getChatRooms(memberId, PageRequest.of(0, 10));
 
     // Then
     assertNotNull(responses);

--- a/src/test/java/com/gogym/chat/service/impl/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/gogym/chat/service/impl/ChatRoomServiceImplTest.java
@@ -166,17 +166,20 @@ class ChatRoomServiceImplTest {
     when(this.chatMessageReadRepository.countUnreadMessages(eq(chatRoomId), eq(memberId))).thenReturn(5);
 
     // When
-    List<ChatRoomResponse> responses = this.chatRoomService.getChatRooms(memberId, 0, 10);
+    Page<ChatRoomResponse> responses = this.chatRoomService.getChatRooms(memberId, 0, 10);
 
     // Then
     assertNotNull(responses);
-    assertEquals(1, responses.size());
+    assertEquals(1, responses.getContent().size());
 
-    ChatRoomResponse response = responses.get(0);
+    ChatRoomResponse response = responses.getContent().get(0);
     
     assertEquals(chatRoomId, response.chatRoomId());
     assertEquals("test message", response.lastMessage());
     assertEquals(5, response.unreadMessageCount());
+    assertEquals(1, responses.getTotalElements());
+    assertEquals(1, responses.getTotalPages());
+    assertFalse(responses.hasNext());
     
     verify(this.chatRoomRepository).findChatRoomsSortedByLastMessage(
         eq(memberId),


### PR DESCRIPTION
## ⚡️ Issue 번호
WebSocket 연결 시 JWT 인증 기능 [#62](https://github.com/ProjectGoGym/BackEnd/issues/62)

## 🛠️ 작업 내용 (What)
- WebSocket 연결 초기 단계에서 클라이언트가 전송하는 JWT를 검증하여 인증된 사용자 정보를 STOMP 세션에 저장
- 이후 메시지 브로드캐스팅 과정에서 해당 정보를 활용
- STOMP 메시지 전처리 및 메시지 브로드캐스팅 과정 개선

## 📌 작업 이유 (Why)
- WebSocket 연결은 상태가 길게 유지되므로 초기 연결 단계에서 인증을 완료하여 이후 통신의 안전성을 보장해야 합니다.
- STOMP 세션에 사용자 정보를 저장하여 메시지 송수신 시 인증 상태를 유지하고, 안전하게 처리해야 합니다.
 
## ✨ 변경 사항 (Changes)
- `WebSocketConfig`
  - Origin 허용 엔드포인트 추가
    - WebSocket 연결에 대해 CORS 정책을 허용할 Origin 패턴을 추가해 다양한 클라이언트 환경에서의 연결을 지원하도록 수정.
  - STOMP 메시지 인터셉터 등록
    - STOMP 메시지의 전처리를 위한 `StompHandler`를 인터셉터로 등록하는 `configureClientInboundChannel()` 메서드 추가
- `StompHandler`
  - STOMP 프로토콜의 `CONNECT` 메시지에서 `Authorization` 헤더를 통해 전송된 JWT 검증.
  - JWT 유효성을 검증하고 사용자 ID를 추출.
  - 인증된 정보를 STOMP 세션에 설정.
- `JwtAuthenticationFilter`
  - WebSocket 초기 연결 요청(`/ws`)의 경우 JWT 인증을 `StompHandler`에서 처리하도록 분리.
- `WebSocketChatController`
  - STOMP 세션에서 사용자 인증 정보 참조
    - STOMP 세션에 저장된 `Principal` 객체를 활용하여 사용자 인증 상태를 확인하고 메시지를 처리.
  - 메시지 송수신 로직 안정화
    - 사용자 인증 상태 확인 후 메시지를 Redis에 저장.
    - 저장된 메시지를 채팅방 구독자에게 브로드캐스트.

## ✅ 테스트 (Tests)
- [x] WebSocket 연결 요청
  - `/ws` 엔드포인트로 WebSocket 연결 요청 시 JWT 인증이 정상적으로 처리되는지 확인.
- [x] STOMP 메시지 송수신
  - 인증된 사용자가 메시지를 송수신할 수 있는지 확인.
- [x] Redis 메시지 저장
  - 채팅 메시지가 Redis에 저장되고 조회되는지 확인.

## 💬 리뷰 포인트 (Review Points)
- 보안
  - WebSocket 연결 초기와 메시지 송수신 시 JWT 인증 로직이 안전하게 구현되었는지 확인 부탁드립니다.
- 코드 설계
  - `StompHandler`에서 JWT 인증 실패 시 Exception 처리가 적절한지 확인 부탁드립니다.
  - `WebSocketChatController`와 `StompHandler` 간 역할 분리가 적절한지 확인 부탁드립니다.
- 테스트 및 예외 처리
  - 추가적으로 고려할 시나리오나 예외 처리가 필요한 부분이 있는지 확인 부탁드립니다.
