### PR TITLE
♻️ refactor: ErrorCode에 WebSocket 인증 관련 예외 값 추가

### DIFF
--- a/src/main/java/com/gogym/exception/ErrorCode.java
+++ b/src/main/java/com/gogym/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
   EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
   EMAIL_NOT_VERIFIED(HttpStatus.UNAUTHORIZED, "이메일 인증이 완료되지 않았습니다."),
+  WEBSOCKET_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "WebSocket 인증에 실패했습니다."),
 
   // 403 FORBIDDEN
   FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),


### PR DESCRIPTION
## 📌 작업 이유 (Why)
WebSocket JWT 인증 간 유요하지 않은 토큰이 들어온 경우 WebSocket 예외를 따로 처리해야한다고 생각했습니다.

## ✨ 변경 사항 (Changes)
`ErrorCode` Enum에 WebSocket JWT 인증 관련 예외 값 추가