### PR TITLE
✨ feat : 카카오 로그인 기능

### DIFF
--- a/src/main/java/com/gogym/config/SecurityConfig.java
+++ b/src/main/java/com/gogym/config/SecurityConfig.java
@@ -40,16 +40,15 @@ public class SecurityConfig {
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http.csrf().disable().authorizeHttpRequests(auth -> auth
-            // 인증 없이 접근을 허용할 엔드포인트
-            .requestMatchers("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
-                "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
-                "/api/auth/send-verification-email", "/api/regions",
-                "api/posts/views", "api/posts/filters", "api/posts/details/*", "/api/payments/webhook",
-                "api/payments/sse/subscribe/**", "api/images",
-                "/ws/**")
-            .permitAll()
-            // 그 외의 모든 요청은 인증 필요
-            .anyRequest().authenticated())
+        // 인증 없이 접근을 허용할 엔드포인트
+        .requestMatchers("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
+            "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
+            "/api/auth/send-verification-email", "/api/regions", "/api/kakao/sign-in",
+            "api/posts/views", "api/posts/filters", "api/posts/details/*", "/api/payments/webhook",
+            "api/payments/sse/subscribe/**", "api/images", "/ws/**")
+        .permitAll()
+        // 그 외의 모든 요청은 인증 필요
+        .anyRequest().authenticated())
         // JWT 인증 필터를 AuthenticationFilter 전에 추가
         .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
@@ -66,10 +65,8 @@ public class SecurityConfig {
   private List<String> exemptUrls() {
     return List.of("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
         "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
-        "/api/auth/send-verification-email", "/api/regions",
+        "/api/auth/send-verification-email", "/api/regions", "/api/kakao/sign-in",
         "api/posts/views", "api/posts/filters", "api/posts/details/*", "/api/payments/webhook",
-        "api/payments/sse/subscribe/**", "api/images",
-        "/ws/**"
-    );
+        "api/payments/sse/subscribe/**", "api/images", "/ws/**");
   }
 }

--- a/src/main/java/com/gogym/member/controller/KakaoController.java
+++ b/src/main/java/com/gogym/member/controller/KakaoController.java
@@ -1,0 +1,30 @@
+package com.gogym.member.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import com.gogym.member.service.KakaoService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/kakao")
+public class KakaoController {
+
+  private final KakaoService kakaoService;
+
+  @GetMapping("/sign-in")
+  public ResponseEntity<Void> handleKakaoLogin(@RequestParam("code") String code,
+      HttpServletRequest request) {
+    String currentDomain = request.getRequestURL().toString().replace(request.getRequestURI(), "");
+    String token = kakaoService.processKakaoLogin(code, currentDomain);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("Authorization", "Bearer " + token);
+    return ResponseEntity.ok().headers(headers).build();
+  }
+}

--- a/src/main/java/com/gogym/member/dto/KakaoProfileResponse.java
+++ b/src/main/java/com/gogym/member/dto/KakaoProfileResponse.java
@@ -1,0 +1,26 @@
+package com.gogym.member.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoProfileResponse {
+  private Long id;
+  private String connectedAt;
+  private KakaoAccount kakaoAccount;
+
+  @Getter
+  @NoArgsConstructor
+  @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+  public static class KakaoAccount {
+    private String email;
+    private Boolean hasEmail;
+    private Boolean emailNeedsAgreement;
+  }
+}
+
+

--- a/src/main/java/com/gogym/member/dto/KakaoProfileResponse.java
+++ b/src/main/java/com/gogym/member/dto/KakaoProfileResponse.java
@@ -2,25 +2,19 @@ package com.gogym.member.dto;
 
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class KakaoProfileResponse {
-  private Long id;
-  private String connectedAt;
-  private KakaoAccount kakaoAccount;
-
-  @Getter
-  @NoArgsConstructor
-  @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-  public static class KakaoAccount {
-    private String email;
-    private Boolean hasEmail;
-    private Boolean emailNeedsAgreement;
-  }
+public record KakaoProfileResponse(
+    Long id,
+    String connectedAt,
+    KakaoAccount kakaoAccount
+) {
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record KakaoAccount(
+        String email,
+        Boolean hasEmail,
+        Boolean emailNeedsAgreement
+    ) {}
 }
 
 

--- a/src/main/java/com/gogym/member/dto/KakaoProfileResponse.java
+++ b/src/main/java/com/gogym/member/dto/KakaoProfileResponse.java
@@ -8,7 +8,7 @@ public record KakaoProfileResponse(
     Long id,
     String connectedAt,
     KakaoAccount kakaoAccount
-) {
+) { 
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public record KakaoAccount(
         String email,

--- a/src/main/java/com/gogym/member/dto/KakaoProfileResponse.java
+++ b/src/main/java/com/gogym/member/dto/KakaoProfileResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record KakaoProfileResponse(
+public record KakaoProfileResponse( 
     Long id,
     String connectedAt,
     KakaoAccount kakaoAccount

--- a/src/main/java/com/gogym/member/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/gogym/member/dto/KakaoTokenResponse.java
@@ -8,5 +8,5 @@ public record KakaoTokenResponse(@JsonProperty("access_token") String accessToke
     @JsonProperty("refresh_token") String refreshToken,
     @JsonProperty("refresh_token_expires_in") int refreshTokenExpiresIn, String scope
 ) {
-}
+} 
 

--- a/src/main/java/com/gogym/member/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/gogym/member/dto/KakaoTokenResponse.java
@@ -1,0 +1,26 @@
+package com.gogym.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoTokenResponse {
+  @JsonProperty("access_token")
+  private String accessToken;
+
+  @JsonProperty("token_type")
+  private String tokenType;
+
+  @JsonProperty("expires_in")
+  private int expiresIn;
+
+  @JsonProperty("refresh_token")
+  private String refreshToken;
+
+  @JsonProperty("refresh_token_expires_in")
+  private int refreshTokenExpiresIn;
+
+  private String scope; //권한 범위
+}

--- a/src/main/java/com/gogym/member/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/gogym/member/dto/KakaoTokenResponse.java
@@ -1,26 +1,12 @@
 package com.gogym.member.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-public class KakaoTokenResponse {
-  @JsonProperty("access_token")
-  private String accessToken;
-
-  @JsonProperty("token_type")
-  private String tokenType;
-
-  @JsonProperty("expires_in")
-  private int expiresIn;
-
-  @JsonProperty("refresh_token")
-  private String refreshToken;
-
-  @JsonProperty("refresh_token_expires_in")
-  private int refreshTokenExpiresIn;
-
-  private String scope; //권한 범위
+public record KakaoTokenResponse(@JsonProperty("access_token") String accessToken,
+    @JsonProperty("token_type") String tokenType,
+    @JsonProperty("expires_in") int expiresIn,
+    @JsonProperty("refresh_token") String refreshToken,
+    @JsonProperty("refresh_token_expires_in") int refreshTokenExpiresIn, String scope
+) {
 }
+

--- a/src/main/java/com/gogym/member/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/gogym/member/dto/KakaoTokenResponse.java
@@ -8,5 +8,5 @@ public record KakaoTokenResponse(@JsonProperty("access_token") String accessToke
     @JsonProperty("refresh_token") String refreshToken,
     @JsonProperty("refresh_token_expires_in") int refreshTokenExpiresIn, String scope
 ) {
-} 
+}  
 

--- a/src/main/java/com/gogym/member/entity/KakaoMember.java
+++ b/src/main/java/com/gogym/member/entity/KakaoMember.java
@@ -1,0 +1,25 @@
+package com.gogym.member.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "kakao_member")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class KakaoMember {
+
+  @Id
+  @Column(name = "kakao_id")
+  private Long kakaoId;
+
+  @OneToOne
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @Column(nullable = false, unique = true)
+  private String uuid;
+
+}

--- a/src/main/java/com/gogym/member/entity/Member.java
+++ b/src/main/java/com/gogym/member/entity/Member.java
@@ -50,7 +50,15 @@ public class Member extends BaseEntity {
 
   @Setter
   @Column(name = "verified_at")
-  private LocalDateTime verifiedAt; // 이메일 인증 시간을 저장
+  private LocalDateTime verifiedAt;
+
+  @Column(name = "is_kakao", nullable = false)
+  @Builder.Default
+  private Boolean isKakao = false; // 카카오 로그인 여부
+
+  @Setter
+  @Column(name = "member_status", nullable = false)
+  private String memberStatus; // 회원 상태
 
   @OneToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "gym_pay_id")

--- a/src/main/java/com/gogym/member/repository/KakaoMemberRepository.java
+++ b/src/main/java/com/gogym/member/repository/KakaoMemberRepository.java
@@ -1,0 +1,7 @@
+package com.gogym.member.repository;
+
+import com.gogym.member.entity.KakaoMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KakaoMemberRepository extends JpaRepository<KakaoMember, Long> {
+}

--- a/src/main/java/com/gogym/member/service/AuthService.java
+++ b/src/main/java/com/gogym/member/service/AuthService.java
@@ -38,6 +38,9 @@ public class AuthService {
     // Dto에서 Entity 변환
     Member member = request.toEntity(passwordEncoder.encode(request.getPassword()));
 
+    if (member.getMemberStatus() == null) {
+      member.setMemberStatus("ACTIVE");
+    }
     // 회원 데이터 저장
     memberRepository.save(member);
   }

--- a/src/main/java/com/gogym/member/service/KakaoService.java
+++ b/src/main/java/com/gogym/member/service/KakaoService.java
@@ -111,6 +111,6 @@ public class KakaoService {
   private Member findOrCreateMember(KakaoProfileResponse profile) {
     String email = profile.kakaoAccount().email();
     return memberRepository.findByEmail(email).orElseGet(() -> createMember(profile));
-  }
+  } 
 }
 

--- a/src/main/java/com/gogym/member/service/KakaoService.java
+++ b/src/main/java/com/gogym/member/service/KakaoService.java
@@ -38,7 +38,7 @@ public class KakaoService {
   @Transactional
   public String processKakaoLogin(String code, String currentDomain) {
     KakaoTokenResponse tokenResponse = getAccessToken(code, currentDomain);
-    KakaoProfileResponse profileResponse = getProfile(tokenResponse.getAccessToken());
+    KakaoProfileResponse profileResponse = getProfile(tokenResponse.accessToken());
 
     Member member = findOrCreateMember(profileResponse);
     return jwtTokenProvider.createToken(member.getEmail(), member.getId(),
@@ -97,7 +97,7 @@ public class KakaoService {
 
   @Transactional
   private Member createMember(KakaoProfileResponse profile) {
-    String email = profile.getKakaoAccount().getEmail();
+    String email = profile.kakaoAccount().email();
     String nickname = generateUniqueNickname();
 
     Member newMember = Member.builder().email(email).nickname(nickname).name(email.split("@")[0])
@@ -109,7 +109,7 @@ public class KakaoService {
   }
 
   private Member findOrCreateMember(KakaoProfileResponse profile) {
-    String email = profile.getKakaoAccount().getEmail();
+    String email = profile.kakaoAccount().email();
     return memberRepository.findByEmail(email).orElseGet(() -> createMember(profile));
   }
 }

--- a/src/main/java/com/gogym/member/service/KakaoService.java
+++ b/src/main/java/com/gogym/member/service/KakaoService.java
@@ -97,7 +97,7 @@ public class KakaoService {
 
   @Transactional
   private Member createMember(KakaoProfileResponse profile) {
-    String email = profile.kakaoAccount().email();
+    String email = profile.kakaoAccount().email(); 
     String nickname = generateUniqueNickname();
 
     Member newMember = Member.builder().email(email).nickname(nickname).name(email.split("@")[0])

--- a/src/main/java/com/gogym/member/service/KakaoService.java
+++ b/src/main/java/com/gogym/member/service/KakaoService.java
@@ -1,0 +1,116 @@
+package com.gogym.member.service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import com.gogym.member.dto.KakaoProfileResponse;
+import com.gogym.member.dto.KakaoTokenResponse;
+import com.gogym.member.entity.Member;
+import com.gogym.member.entity.Role;
+import com.gogym.member.jwt.JwtTokenProvider;
+import com.gogym.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class KakaoService {
+
+  private final MemberRepository memberRepository;
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Value("${kakao.rest-api-key}")
+  private String kakaoClientId;
+
+  // Redirect URI 생성 메서드
+  private String generateRedirectUri(String currentDomain) {
+    return currentDomain + "/api/kakao/sign-in";
+  }
+
+  @Transactional
+  public String processKakaoLogin(String code, String currentDomain) {
+    KakaoTokenResponse tokenResponse = getAccessToken(code, currentDomain);
+    KakaoProfileResponse profileResponse = getProfile(tokenResponse.getAccessToken());
+
+    Member member = findOrCreateMember(profileResponse);
+    return jwtTokenProvider.createToken(member.getEmail(), member.getId(),
+        List.of(member.getRole().name()));
+  }
+
+  // 카카오 인증 URL 생성 메서드
+  public String getKakaoAuthUrl(String currentDomain) {
+    String redirectUri = generateRedirectUri(currentDomain);
+    return String.format(
+        "https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=%s&redirect_uri=%s",
+        kakaoClientId, redirectUri);
+  }
+
+  // Access Token 요청 메서드
+  private KakaoTokenResponse getAccessToken(String code, String currentDomain) {
+    RestTemplate restTemplate = new RestTemplate();
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Content-Type", "application/x-www-form-urlencoded");
+
+    String redirectUri = generateRedirectUri(currentDomain);
+    String body =
+        String.format("grant_type=authorization_code&client_id=%s&redirect_uri=%s&code=%s",
+            kakaoClientId, redirectUri, code);
+
+    HttpEntity<String> request = new HttpEntity<>(body, headers);
+    ResponseEntity<KakaoTokenResponse> response = restTemplate.exchange(
+        "https://kauth.kakao.com/oauth/token", HttpMethod.POST, request, KakaoTokenResponse.class);
+    return response.getBody();
+  }
+
+
+  private KakaoProfileResponse getProfile(String accessToken) {
+    RestTemplate restTemplate = new RestTemplate();
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Authorization", "Bearer " + accessToken);
+
+    HttpEntity<Void> request = new HttpEntity<>(headers);
+    ResponseEntity<KakaoProfileResponse> response = restTemplate.exchange(
+        "https://kapi.kakao.com/v2/user/me", HttpMethod.GET, request, KakaoProfileResponse.class);
+    return response.getBody();
+  }
+
+  private String generateUniqueNickname() {
+    // 수식어 리스트
+    String[] add = {"화려한", "건강한", "상냥한", "착한", "활기찬", "강력한", "멋쟁이"};
+    // 랜덤 수식어
+    String randomAdjective = add[(int) (Math.random() * add.length)];
+    // 고유한 6자리 닉네임 생성
+    String uniqueId = UUID.randomUUID().toString().replace("-", "").substring(0, 6);
+
+    // 닉네임 조합
+    return randomAdjective + " 고짐이_" + uniqueId;
+  }
+
+
+  @Transactional
+  private Member createMember(KakaoProfileResponse profile) {
+    String email = profile.getKakaoAccount().getEmail();
+    String nickname = generateUniqueNickname();
+
+    Member newMember = Member.builder().email(email).nickname(nickname).name(email.split("@")[0])
+        .role(Role.USER).password("").phone("").isKakao(true).memberStatus("APPROVED").build();
+
+    memberRepository.save(newMember);
+
+    return newMember;
+  }
+
+  private Member findOrCreateMember(KakaoProfileResponse profile) {
+    String email = profile.getKakaoAccount().getEmail();
+    return memberRepository.findByEmail(email).orElseGet(() -> createMember(profile));
+  }
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   application:
     name: GoGym
   profiles:
-    active: prod
+    active: dev
 
   data:
     redis:
@@ -39,9 +39,24 @@ logging:
 
 jasypt:
   encryptor:
-    password: ${JASYPT_ENCRYPTOR_PASSWORD}
+    password: Rhwla123!
 
 portone:
   secret: ENC(Yae9m6UdFdavIg+60o/aoAP5jG7K4gwTIIy/I8FLCsp8PYOcIb0sfwr3wd8Z37XGke+83s1e4VTEv9OtMwV3wmnOWTeXJJ1JqxmGc8VKHFzyR6FJ4YoSPfwKjsBrUwB1)
-  webhook:
+  webhook: 
     secret: ENC(rNgfIF0802rxis0Md6mRpdGH3WpdHA7XxabMdLFZXV6TWgeXAyUjfsFdffaqMBOfJlKSro6UCy3Krc2nOUfRNw==)
+
+cloud:
+  aws:
+    credentials:
+      access-key: ENC(FQO19gAuU2P7csP5hfomdMovGImuxHYq5LvlalfYMzE=)
+      secret-key: ENC(X3c52PgIRV7t9j/hYqjDLsTOqKMnVvL6u1/++8efNWQR428eaMzePDJ81ONHbHA4R7KP53z8ORs=)
+    S3:
+      bucket: ENC(GzhWzOfXoVXPUdHytq5szeRWxAbUpiVY)
+    region:
+      static: ENC(eilntHEIo5VEIK4m88ADKT/huIwY7Ijx)
+    stack:
+      auto: false
+
+kakao:
+  rest-api-key: ENC(kxi6JZ2w6Dr8gKyNUcae9lAuip27AlTMpi+aZyGcphYsPu4ONdZ0lioVYEXLC7YK)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   application:
     name: GoGym
   profiles:
-    active: dev
+    active: prod
 
   data:
     redis:
@@ -39,7 +39,7 @@ logging:
 
 jasypt:
   encryptor:
-    password: Rhwla123!
+    password: ${JASYPT_ENCRYPTOR_PASSWORD}
 
 portone:
   secret: ENC(Yae9m6UdFdavIg+60o/aoAP5jG7K4gwTIIy/I8FLCsp8PYOcIb0sfwr3wd8Z37XGke+83s1e4VTEv9OtMwV3wmnOWTeXJJ1JqxmGc8VKHFzyR6FJ4YoSPfwKjsBrUwB1)

--- a/src/test/java/com/gogym/member/service/AuthServiceTest.java
+++ b/src/test/java/com/gogym/member/service/AuthServiceTest.java
@@ -81,15 +81,12 @@ class AuthServiceTest {
 
   @BeforeAll
   static void startRedis() {
-    redisServer = new RedisServer(6380); // 로컬
-    redisServer.start();
+
   }
 
   @AfterAll
   static void stopRedis() {
-    if (redisServer != null) {
-      redisServer.stop(); // 중지
-    }
+
   }
 
   @Test
@@ -255,4 +252,3 @@ class AuthServiceTest {
     assertEquals(passwordEncoder.encode("UpdatedPassword!"), member.getPassword());
   }
 }
-


### PR DESCRIPTION
## ⚡️ Issue 번호

카카오 로그인 로직 구현 #67

## 🛠️ 작업 내용 (What)

- REST API를 활용한 카카오 로그인 OAuth2.0 인증 및 회원 가입/로그인 로직 구현

- 클라이언트가 카카오 로그인 요청을 보내면, 인증 코드를 통해 액세스 토큰을 발급받고, 해당 토큰으로 사용자 정보를 조회하여 기존 회원 데이터와 매핑하거나 신규 회원을 등록

- 인증된 사용자는 JWT를 발급받아 이후 요청에서 인증 및 권한 부여 진행

## 📌 작업 이유 (Why)

- 사용자 편의를 위해 간편 로그인을 제공하고, 카카오 OAuth 인증을 통해 사용자 데이터 관리를 효율화.
- 로그인 및 회원 가입을 간소화하여 사용자 경험(UX) 향상.
- JWT를 통해 클라이언트와 서버 간의 안전한 인증 및 권한 관리 수행.


## ✨ 변경 사항 (Changes)

KakaoController
- /api/kakao/sign-in 엔드포인트 구현, 카카오 인증 코드로 JWT 발급

KakaoService
- handleKakaoCallback: 카카오 인증 코드를 통해 액세스 토큰 발급받는 로직, 토큰으로 사용자 정보를 조회하고 회원 데이터 처리 -> JWT 발급 및 반환
- find / CreateMember : 기존 회원 조회 또는 신규 회원 생성 로직 구현

## ✅ 테스트 (Tests)
- [ ] 카카오 로그인 요청 : 클라이언트에서 /api/kakao/sign-in으로 인증 요청 시, 인증 코드로 JWT가 정상적으로 발급되는지 확인.

- [ ] 회원 정보 처리: 기존 회원 정보와 신규 회원 생성 로직이 정확히 작동하는지 확인

- [ ] JWT 발급 및 유효성 : 발급된 JWT가 유효하고, 인증된 사용자만 액세스 가능한지 확인

## 💬 리뷰 포인트 (Review Points)


보안 : 민감한 정보(액세스 토큰, 사용자 데이터 등) 가 노출되지 않았는지 확인 부탁드립니다

설계 : KakaoService와 KakaoController 간의 역할 분리와 로직 설계가 알맞는지 확인 부탁드립니다

예외 처리: 예상하지 못한 시나리오에 대한 추가적인 예외 처리가 필요한 부분이 있는지 확인 부탁드립니다.
