### PR TITLE
✨feat : 게시글 상태를 변경하여 거래 상태를 변경하는 메서드 구현, 알림기능 refactor

### DIFF
--- a/src/main/java/com/gogym/config/SecurityConfig.java
+++ b/src/main/java/com/gogym/config/SecurityConfig.java
@@ -40,15 +40,17 @@ public class SecurityConfig {
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http.csrf().disable().authorizeHttpRequests(auth -> auth
-        // 인증 없이 접근을 허용할 엔드포인트
-        .requestMatchers("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
-            "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
-            "/api/auth/send-verification-email", "/api/regions", "/api/kakao/sign-in",
-            "api/posts/views", "api/posts/filters", "api/posts/details/*", "/api/payments/webhook",
-            "/api/payments/sse/subscribe/**", "/api/images/presigned-url", "/ws/**")
-        .permitAll()
-        // 그 외의 모든 요청은 인증 필요
-        .anyRequest().authenticated())
+            // 인증 없이 접근을 허용할 엔드포인트
+            .requestMatchers("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
+                "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
+                "/api/auth/send-verification-email", "/api/regions", "/api/kakao/sign-in",
+                "/api/posts/views", "/api/posts/filters", "/api/posts/details/**",
+                "/api/payments/webhook",
+                "/api/payments/sse/subscribe/**", "/api/images/presigned-url", "/ws/**",
+                "/api/notifications/subscribe/**")
+            .permitAll()
+            // 그 외의 모든 요청은 인증 필요
+            .anyRequest().authenticated())
         // JWT 인증 필터를 AuthenticationFilter 전에 추가
         .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
@@ -66,7 +68,8 @@ public class SecurityConfig {
     return List.of("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
         "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
         "/api/auth/send-verification-email", "/api/regions", "/api/kakao/sign-in",
-        "api/posts/views", "api/posts/filters", "api/posts/details/*", "/api/payments/webhook",
-        "/api/payments/sse/subscribe/**", "/api/images/presigned-url", "/ws/**");
+        "/api/posts/views", "/api/posts/filters", "/api/posts/details/**", "/api/payments/webhook",
+        "/api/payments/sse/subscribe/**", "/api/images/presigned-url", "/ws/**",
+        "/api/notifications/subscribe/**");
   }
 }

--- a/src/main/java/com/gogym/config/WebConfig.java
+++ b/src/main/java/com/gogym/config/WebConfig.java
@@ -3,6 +3,7 @@ package com.gogym.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import com.gogym.aop.LoginMemberIdHandler;
 import java.util.List;
@@ -18,5 +19,17 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
     resolvers.add(memberIdResolver);
+  }
+
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/**")  // 모든 엔드포인트에 대해 CORS 설정
+        .allowedOrigins( // 프론트엔드 주소
+            "http://localhost:3001",
+            "http://localhost:3000",
+            "https://gogym-eight.vercel.app/")
+        .allowedMethods("*")  // 허용할 HTTP 메서드
+        .allowedHeaders("*")  // 모든 헤더 허용
+        .allowCredentials(true);  // 자격증명(쿠키, 인증 헤더 등)을 포함하는 요청 허용
   }
 }

--- a/src/main/java/com/gogym/exception/ErrorCode.java
+++ b/src/main/java/com/gogym/exception/ErrorCode.java
@@ -41,6 +41,7 @@ public enum ErrorCode {
   SSE_SUBSCRIPTION_NOT_FOUND(NOT_FOUND, "요청한 구독 정보가 존재하지 않습니다."),
   LOCK_KEY_NOT_FOUND(NOT_FOUND, "RedissonLock Key가 존재하지 않습니다."),
   SAFE_PAYMENT_NOT_FOUND(NOT_FOUND, "안전거래를 찾을 수 없습니다."),
+  TRANSACTION_NOT_FOUND(NOT_FOUND, "거래를 찾을 수 없습니다."),
 
   // 408 REQUEST TIMEOUT
   SSE_TIMEOUT(REQUEST_TIMEOUT, "SSE 연결 시간이 초과되었습니다."),
@@ -52,6 +53,7 @@ public enum ErrorCode {
   CHATROOM_ALREADY_EXISTS(CONFLICT, "이미 존재하는 채팅방입니다."),
   PAYMENT_MISMATCH(CONFLICT, "결제 정보가 일치하지 않습니다."),
   NOT_IN_PROGRESS(CONFLICT, "거래 중이 아닙니다."),
+  ALREADY_TRANSACTION(CONFLICT, "이미 거래중인 게시글 입니다."),
 
   // 423 LOCKED
   LOCK_ACQUISITION_FAILED(LOCKED, "해당 리소스에 락을 획득할 수 없습니다."),

--- a/src/main/java/com/gogym/gympay/event/listener/PaymentEventListener.java
+++ b/src/main/java/com/gogym/gympay/event/listener/PaymentEventListener.java
@@ -15,11 +15,11 @@ public class PaymentEventListener {
 
   @TransactionalEventListener
   public void handlePaymentPaid(PaidEvent event) {
-//    sseService.sendUpdate(event.paymentId(), event.sseEventName());
+    sseService.sendUpdate(event.paymentId(), event.sseEventName());
   }
 
   @TransactionalEventListener
   public void handlePaymentFailed(FailedEvent event) {
-//    sseService.sendUpdate(event.paymentId(), event.sseEventName(), event.failureReason());
+    sseService.sendUpdate(event.paymentId(), event.sseEventName(), event.failureReason());
   }
 }

--- a/src/main/java/com/gogym/member/controller/AuthController.java
+++ b/src/main/java/com/gogym/member/controller/AuthController.java
@@ -1,22 +1,27 @@
 package com.gogym.member.controller;
 
+import com.gogym.member.dto.LoginResponse;
+import com.gogym.member.dto.ResetPasswordRequest;
+import com.gogym.member.dto.SignInRequest;
 import com.gogym.member.dto.SignUpRequest;
 import com.gogym.member.entity.Member;
-import com.gogym.member.dto.SignInRequest;
-import com.gogym.member.dto.ResetPasswordRequest;
-import com.gogym.common.annotation.LoginMemberId;
-import com.gogym.member.dto.LoginResponse;
 import com.gogym.member.service.AuthService;
 import com.gogym.member.service.EmailService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 import java.net.URI;
 import java.net.URISyntaxException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -41,9 +46,12 @@ public class AuthController {
 
     // 사용자 정보를 가져오기
     Member member = authService.getMemberByEmail(request.getEmail());
-    LoginResponse loginResponse = new LoginResponse(member.getEmail(), member.getName(),
-        member.getNickname(), member.getPhone()
-
+    LoginResponse loginResponse = new LoginResponse(
+        member.getId(),
+        member.getEmail(),
+        member.getName(),
+        member.getNickname(),
+        member.getPhone()
     );
 
     // HttpHeaders를 사용하여 헤더에 Authorization 추가

--- a/src/main/java/com/gogym/member/controller/AuthController.java
+++ b/src/main/java/com/gogym/member/controller/AuthController.java
@@ -33,8 +33,9 @@ public class AuthController {
 
   // 회원가입
   @PostMapping("/sign-up")
-  public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
-    authService.signUp(request);
+  public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request,
+      @RequestParam(defaultValue = "false") boolean isKakao) {
+    authService.signUp(request, isKakao);
     return ResponseEntity.status(HttpStatus.OK).build();
   }
 

--- a/src/main/java/com/gogym/member/controller/KakaoController.java
+++ b/src/main/java/com/gogym/member/controller/KakaoController.java
@@ -18,13 +18,17 @@ public class KakaoController {
   private final KakaoService kakaoService;
 
   @GetMapping("/sign-in")
-  public ResponseEntity<Void> handleKakaoLogin(@RequestParam("code") String code,
+  public ResponseEntity<Object> handleKakaoLogin(@RequestParam("code") String code,
       HttpServletRequest request) {
     String currentDomain = request.getRequestURL().toString().replace(request.getRequestURI(), "");
-    String token = kakaoService.processKakaoLogin(code, currentDomain);
+    String token = kakaoService.processKakaoLogin(code, currentDomain); //카카오 로그인 처리
+
+    if (token == null) {
+      return ResponseEntity.ok(false); // 회원 정보가 없거나 isKakao == false: 클라이언트에 false 반환
+    }
 
     HttpHeaders headers = new HttpHeaders();
     headers.add("Authorization", "Bearer " + token);
-    return ResponseEntity.ok().headers(headers).build();
+    return ResponseEntity.ok().headers(headers).body(true);
   }
 }

--- a/src/main/java/com/gogym/member/dto/LoginResponse.java
+++ b/src/main/java/com/gogym/member/dto/LoginResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class LoginResponse {
   // 프론트앤드 분들 요청사항으로 로그인 후 반환값을 추가했습니다.
+  private Long memberId;
   private String email;
   private String name;
   private String nickname;

--- a/src/main/java/com/gogym/member/dto/ResetPasswordRequest.java
+++ b/src/main/java/com/gogym/member/dto/ResetPasswordRequest.java
@@ -18,5 +18,8 @@ public class ResetPasswordRequest {
   private String email;
 
   @NotBlank
+  private String currentPassword;
+
+  @NotBlank
   private String newPassword;
 }

--- a/src/main/java/com/gogym/member/entity/Member.java
+++ b/src/main/java/com/gogym/member/entity/Member.java
@@ -4,20 +4,15 @@ import com.gogym.common.entity.BaseEntity;
 import com.gogym.gympay.entity.GymPay;
 import com.gogym.gympay.entity.Payment;
 import com.gogym.gympay.entity.Transaction;
+import com.gogym.member.type.MemberStatus;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import com.gogym.member.type.MemberStatus;
-import jakarta.persistence.*;
-import lombok.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -79,13 +74,9 @@ public class Member extends BaseEntity {
   @Column(name = "verified_at")
   private LocalDateTime verifiedAt; // 이메일 인증 시간
 
-  @Column(name = "is_kakao", nullable = false)
-  @Builder.Default
-  private Boolean isKakao = false; // 카카오 로그인 여부
-
   @Setter
-  @Column(name = "member_status", nullable = false)
-  private String memberStatus; // 회원 상태
+  @Column(name = "is_kakao")
+  private boolean isKakao = false; // 카카오 로그인 여부
 
   @Setter
   @OneToOne(mappedBy = "member", cascade = CascadeType.PERSIST)
@@ -112,6 +103,4 @@ public class Member extends BaseEntity {
     this.phone = phone;
     this.profileImageUrl = profileImageUrl;
   }
-
 }
-

--- a/src/main/java/com/gogym/member/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/gogym/member/jwt/JwtAuthenticationFilter.java
@@ -1,27 +1,35 @@
 package com.gogym.member.jwt;
 
-import java.io.IOException;
-import java.util.List;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.filter.OncePerRequestFilter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtTokenProvider jwtTokenProvider;
   private final List<String> exemptUrls;
+  private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
   @Override
   protected boolean shouldNotFilter(HttpServletRequest request) {
     String path = request.getRequestURI();
 
+    // 와일드카드를 넣어도 문자열로 인식하기 때문에 정확한 판단이 어려워서 추가 구현했습니다.
+    for (String exemptUrl : exemptUrls) {
+      if (pathMatcher.match(exemptUrl, path)) {
+        return true;
+      }
+    }
 
     // WebSocket 초기 연결 요청 시에는 Interceptor에서 확인
     if (path.startsWith("/ws")) {

--- a/src/main/java/com/gogym/member/service/KakaoService.java
+++ b/src/main/java/com/gogym/member/service/KakaoService.java
@@ -1,8 +1,13 @@
 package com.gogym.member.service;
 
+import com.gogym.member.dto.KakaoProfileResponse;
+import com.gogym.member.dto.KakaoTokenResponse;
+import com.gogym.member.entity.Member;
+import com.gogym.member.jwt.JwtTokenProvider;
+import com.gogym.member.repository.MemberRepository;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -11,14 +16,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
-import com.gogym.member.dto.KakaoProfileResponse;
-import com.gogym.member.dto.KakaoTokenResponse;
-import com.gogym.member.entity.Member;
-import com.gogym.member.entity.Role;
-import com.gogym.member.jwt.JwtTokenProvider;
-import com.gogym.member.repository.MemberRepository;
-import com.gogym.member.type.MemberStatus;
-import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -38,10 +35,26 @@ public class KakaoService {
 
   @Transactional
   public String processKakaoLogin(String code, String currentDomain) {
+    // 1. Access Token 및 프로필 정보 획득
     KakaoTokenResponse tokenResponse = getAccessToken(code, currentDomain);
     KakaoProfileResponse profileResponse = getProfile(tokenResponse.accessToken());
 
-    Member member = findOrCreateMember(profileResponse);
+    // 2. 이메일로 회원 정보 조회
+    String email = profileResponse.kakaoAccount().email();
+    Optional<Member> optionalMember = memberRepository.findByEmail(email);
+
+    if (optionalMember.isEmpty()) {
+      return null; // 회원 정보가 없는 경우는 클라이언트에 false 반환
+    }
+
+    Member member = optionalMember.get();
+
+    // 3. isKakao 여부 확인
+    if (!member.isKakao()) {
+      return null; // 일반 회원가입 진행 필요
+    }
+
+    // 4. 로그인 진행: JWT 토큰 발행
     return jwtTokenProvider.createToken(member.getEmail(), member.getId(),
         List.of(member.getRole().name()));
   }
@@ -83,36 +96,4 @@ public class KakaoService {
     return response.getBody();
   }
 
-  private String generateUniqueNickname() {
-    // 수식어 리스트
-    String[] add = {"화려한", "건강한", "상냥한", "착한", "활기찬", "강력한", "멋쟁이"};
-    // 랜덤 수식어
-    String randomAdjective = add[(int) (Math.random() * add.length)];
-    // 고유한 6자리 닉네임 생성
-    String uniqueId = UUID.randomUUID().toString().replace("-", "").substring(0, 6);
-
-    // 닉네임 조합
-    return randomAdjective + " 고짐이_" + uniqueId;
-  }
-
-
-  @Transactional
-  private Member createMember(KakaoProfileResponse profile) {
-    String email = profile.kakaoAccount().email();
-    String nickname = generateUniqueNickname();
-
-    Member newMember =
-        Member.builder().email(email).nickname(nickname).name(email.split("@")[0]).role(Role.USER)
-            .password("").phone("").isKakao(true).memberStatus(MemberStatus.ACTIVE).build();
-
-    memberRepository.save(newMember);
-
-    return newMember;
-  }
-
-  private Member findOrCreateMember(KakaoProfileResponse profile) {
-    String email = profile.kakaoAccount().email();
-    return memberRepository.findByEmail(email).orElseGet(() -> createMember(profile));
-  }
 }
-

--- a/src/main/java/com/gogym/notification/controller/NotificationController.java
+++ b/src/main/java/com/gogym/notification/controller/NotificationController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE;
 import com.gogym.common.annotation.LoginMemberId;
 import com.gogym.notification.dto.NotificationDto;
 import com.gogym.notification.service.NotificationService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -24,7 +26,15 @@ public class NotificationController {
   private final NotificationService notificationService;
 
   @GetMapping(value = "/subscribe", produces = TEXT_EVENT_STREAM_VALUE)
-  public SseEmitter subscribe(@LoginMemberId Long memberId) {
+  public SseEmitter subscribe(HttpServletResponse response,
+      @RequestParam("id") Long memberId) {
+
+    response.setHeader("Access-Control-Allow-Origin", "*");
+    response.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+    response.setHeader("Access-Control-Allow-Headers", "Content-Type");
+    response.setHeader("Cache-Control", "no-cache");
+    response.setHeader("Connection", "keep-alive");
+    response.setHeader("Content-Type", TEXT_EVENT_STREAM_VALUE);
 
     return notificationService.subscribe(memberId);
   }

--- a/src/main/java/com/gogym/notification/service/NotificationService.java
+++ b/src/main/java/com/gogym/notification/service/NotificationService.java
@@ -31,7 +31,7 @@ public class NotificationService {
 
   private final MemberService memberService;
 
-  private static final Long sseTimeOut = 60000L;
+  private static final Long SSE_TIME_OUT = 60000L;
 
   @Getter
   private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
@@ -40,7 +40,7 @@ public class NotificationService {
 
     memberService.findById(memberId);
 
-    SseEmitter emitter = new SseEmitter(sseTimeOut);
+    SseEmitter emitter = new SseEmitter(SSE_TIME_OUT);
     emitters.put(memberId, emitter);
 
     // 클라이언트 연결 종료, 만료, 에러 처리

--- a/src/main/java/com/gogym/post/controller/PostController.java
+++ b/src/main/java/com/gogym/post/controller/PostController.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -100,11 +101,24 @@ public class PostController {
   }
 
   // 게시글을 찜 추가, 삭제 합니다.
-  @PostMapping("{post-id}/wishes")
+  @PostMapping("/{post-id}/wishes")
   public ResponseEntity<Void> toggleWish(@LoginMemberId Long memberId,
       @PathVariable("post-id") Long postId) {
 
     wishService.toggleWish(memberId, postId);
+
+    return ResponseEntity.ok().build();
+  }
+
+  // 게시글의 상태를 변경합니다.
+  @PatchMapping("/{post-id}/change")
+  public ResponseEntity<Void> changePostStatus(
+      @LoginMemberId Long memberId,
+      @PathVariable("post-id") Long postId,
+      @RequestParam("chat-room-id") Long chatRoomId,
+      @RequestParam("status") PostStatus status) {
+
+    postService.changePostStatus(memberId, postId, chatRoomId, status);
 
     return ResponseEntity.ok().build();
   }

--- a/src/main/java/com/gogym/post/dto/PostResponseDto.java
+++ b/src/main/java/com/gogym/post/dto/PostResponseDto.java
@@ -32,11 +32,12 @@ public record PostResponseDto(
     String gymKakaoUrl,
     String city,
     String district,
-    LocalDateTime createdAt
+    LocalDateTime createdAt,
+    boolean isWished
 
 ) {
 
-  public static PostResponseDto fromEntity(Post post, RegionResponseDto regionResponseDto) {
+  public static PostResponseDto fromEntity(Post post, RegionResponseDto regionResponseDto, boolean isWished) {
 
     return PostResponseDto.builder()
         .postId(post.getId())
@@ -60,6 +61,7 @@ public record PostResponseDto(
         .city(regionResponseDto.city())
         .district(regionResponseDto.district())
         .createdAt(post.getCreatedAt())
+        .isWished(isWished)
         .build();
   }
 }

--- a/src/main/java/com/gogym/post/entity/Post.java
+++ b/src/main/java/com/gogym/post/entity/Post.java
@@ -1,8 +1,9 @@
 package com.gogym.post.entity;
 
 import static com.gogym.exception.ErrorCode.REQUEST_VALIDATION_FAIL;
-import static com.gogym.post.type.PostStatus.POSTING;
+import static com.gogym.post.type.PostStatus.PENDING;
 
+import com.gogym.chat.entity.ChatRoom;
 import com.gogym.common.entity.BaseEntity;
 import com.gogym.exception.CustomException;
 import com.gogym.member.entity.Member;
@@ -11,6 +12,7 @@ import com.gogym.post.dto.PostUpdateRequestDto;
 import com.gogym.post.type.MembershipType;
 import com.gogym.post.type.PostStatus;
 import com.gogym.post.type.PostType;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -18,8 +20,11 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -81,6 +86,12 @@ public class Post extends BaseEntity {
   @Column(name = "remaining_sessions")
   private Long remainingSessions;
 
+  @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST)
+  private List<Wish> wishes = new ArrayList<>();
+
+  @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST)
+  private List<ChatRoom> chatRoom = new ArrayList<>();
+
   public static Post of (Member member, Gym gym, PostRequestDto postRequestDto) {
 
     return Post.builder()
@@ -89,7 +100,7 @@ public class Post extends BaseEntity {
         .title(postRequestDto.title())
         .content(postRequestDto.content())
         .postType(postRequestDto.postType())
-        .status(POSTING)
+        .status(PENDING)
         .amount(postRequestDto.amount())
         .imageUrl1(postRequestDto.imageUrl1())
         .imageUrl2(postRequestDto.imageUrl2())
@@ -114,6 +125,10 @@ public class Post extends BaseEntity {
     imageUrl1 = postUpdateRequestDto.imageUrl1();
     imageUrl2 = postUpdateRequestDto.imageUrl2();
     imageUrl3 = postUpdateRequestDto.imageUrl3();
+  }
+
+  public void updateStatus(PostStatus status) {
+    this.status = status;
   }
 
   // 엔티티에서 Not Null 로 설정해두어 별도의 null 값 체크는 없습니다.

--- a/src/main/java/com/gogym/post/repository/PostRepository.java
+++ b/src/main/java/com/gogym/post/repository/PostRepository.java
@@ -22,4 +22,14 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 
   @Query("SELECT p.status FROM Post p WHERE p.id = :postId")
   Optional<PostStatus> findStatusByPostId(@Param("postId") Long postId);
+
+  @Query("""
+      SELECT COUNT(c) > 0
+      FROM Post p
+      JOIN p.chatRoom c
+      JOIN Transaction t ON c.transactionId = t.id
+      WHERE p.id = :postId
+      AND t.status IN ('COMPLETED', 'STARTED')
+  """)
+  boolean existsChatRoomWithTransactionInProgressOrCompleted(@Param("postId") Long postId);
 }

--- a/src/main/java/com/gogym/post/service/PostService.java
+++ b/src/main/java/com/gogym/post/service/PostService.java
@@ -1,13 +1,23 @@
 package com.gogym.post.service;
 
+import static com.gogym.exception.ErrorCode.ALREADY_TRANSACTION;
+import static com.gogym.exception.ErrorCode.CHATROOM_NOT_FOUND;
 import static com.gogym.exception.ErrorCode.DELETED_POST;
 import static com.gogym.exception.ErrorCode.FORBIDDEN;
 import static com.gogym.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static com.gogym.exception.ErrorCode.POST_NOT_FOUND;
+import static com.gogym.exception.ErrorCode.REQUEST_VALIDATION_FAIL;
+import static com.gogym.gympay.entity.constatnt.TransactionStatus.COMPLETED;
+import static com.gogym.gympay.entity.constatnt.TransactionStatus.STARTED;
 import static com.gogym.post.type.PostStatus.HIDDEN;
-import static com.gogym.post.type.PostStatus.POSTING;
+import static com.gogym.post.type.PostStatus.IN_PROGRESS;
+import static com.gogym.post.type.PostStatus.PENDING;
+import static com.gogym.post.type.PostType.SELL;
 
+import com.gogym.chat.entity.ChatRoom;
 import com.gogym.exception.CustomException;
+import com.gogym.gympay.entity.Transaction;
+import com.gogym.gympay.service.TransactionService;
 import com.gogym.member.entity.Member;
 import com.gogym.member.service.MemberService;
 import com.gogym.post.dto.PostFilterRequestDto;
@@ -28,6 +38,7 @@ import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,6 +59,8 @@ public class PostService {
 
   private final RecentViewService recentViewService;
 
+  private final TransactionService transactionService;
+
   @Transactional
   public PostResponseDto createPost(Long memberId, PostRequestDto postRequestDto) {
 
@@ -61,7 +74,7 @@ public class PostService {
 
     RegionResponseDto regionResponseDto = regionService.findById(post.getGym().getRegionId());
 
-    return PostResponseDto.fromEntity(post, regionResponseDto);
+    return PostResponseDto.fromEntity(post, regionResponseDto, false);
   }
 
   // 회원 ID 가 null 이면 비회원, null 이 아니면 회원이 게시글 목록을 보는 상황입니다.
@@ -89,8 +102,8 @@ public class PostService {
     if (postFilterRequestDto == null) {
       posts =
           regionIds == null ?
-              postRepository.findAllByStatusOrderByCreatedAtDesc(pageable, POSTING)
-              : postRepository.findAllByStatusAndRegionIds(POSTING, pageable, regionIds);
+              postRepository.findAllByStatusOrderByCreatedAtDesc(pageable, PENDING)
+              : postRepository.findAllByStatusAndRegionIds(PENDING, pageable, regionIds);
     } else {
 
       posts = postRepositoryCustom.findAllWithFilter(regionIds, postFilterRequestDto, pageable);
@@ -116,9 +129,11 @@ public class PostService {
       recentViewService.saveRecentView(member, post);
     }
 
+    boolean isWished = isWished(post, memberId);
+
     RegionResponseDto regionResponseDto = regionService.findById(post.getGym().getRegionId());
 
-    return PostResponseDto.fromEntity(post, regionResponseDto);
+    return PostResponseDto.fromEntity(post, regionResponseDto, isWished);
   }
 
   // 게시글 수정 메서드입니다
@@ -130,9 +145,13 @@ public class PostService {
 
     Post post = findById(postId);
 
-    // 게시글 작성자만 게시글 수정 권한이 있습니다
-    if (post.getAuthor() != member) {
-      throw new CustomException(FORBIDDEN);
+    boolean isWished = isWished(post, memberId);
+
+    validatePostAuthor(member, post);
+
+    // 게시글 상태는 게시중(거래대기) 또는 숨김처리(삭제) 만 변경할 수 있습니다.
+    if (postUpdateRequestDto.status() != PENDING && postUpdateRequestDto.status() != HIDDEN) {
+      throw new CustomException(REQUEST_VALIDATION_FAIL);
     }
 
     post.update(postUpdateRequestDto);
@@ -140,7 +159,7 @@ public class PostService {
     // 게시글의 전체 필드를 반환합니다.
     RegionResponseDto regionResponseDto = regionService.findById(post.getGym().getRegionId());
 
-    return PostResponseDto.fromEntity(post, regionResponseDto);
+    return PostResponseDto.fromEntity(post, regionResponseDto, isWished);
   }
 
   // 회원의 경우 설정된 관심지역을 가져옵니다.
@@ -153,24 +172,6 @@ public class PostService {
         .toList();
 
     return regionIds.isEmpty() ? null : regionIds;
-  }
-
-  // 주어진 게시글 ID 로 게시글을 찾습니다.
-  public Post findById(Long postId) {
-
-    return postRepository.findById(postId).orElseThrow(() -> new CustomException(POST_NOT_FOUND));
-  }
-
-  // 채팅방 에서 호출할 메서드입니다. 게시글 작성자를 찾습니다.
-  public Member getPostAuthor(Long postId) {
-
-    Post post = findById(postId);
-
-    if (post.getAuthor() == null) {
-      throw new CustomException(MEMBER_NOT_FOUND);
-    } else {
-      return post.getAuthor();
-    }
   }
 
   // 특정 회원의 아이디로 특정 회원의 게시글 목록을 반환하는 메서드 입니다.
@@ -193,5 +194,130 @@ public class PostService {
 
     return postRepository.findStatusByPostId(postId)
         .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+  }
+
+  // 게시글의 상태 변경을 전용으로 하는 메서드입니다.
+  @Transactional
+  public void changePostStatus(Long memberId, Long postId, Long chatRoomId, PostStatus status) {
+
+    Member member = memberService.findById(memberId);
+    Post post = findById(postId);
+    ChatRoom chatRoom = getChatRoom(post, chatRoomId);
+
+    validatePostAuthor(member, post);
+
+    // Seller 와 Buyer 를 설정 합니다.
+    Pair<Member, Member> role = getRole(post, chatRoom);
+    Member seller = role.getFirst();
+    Member buyer = role.getSecond();
+
+    // 요청값이 현재 변경할 수 있는 값이 아니면 예외를 던집니다.
+    if (!isValidStatus(post.getStatus(), status)) {
+
+      throw new CustomException(REQUEST_VALIDATION_FAIL,
+          String.format("'%s' 상태는 '%s' 상태로 변경할 수 없습니다.",
+              post.getStatus().getStatusName(), status.getStatusName()));
+    }
+
+    Transaction transaction = chatRoom.getTransaction();
+
+    post.updateStatus(status);
+
+    handleTransactionStatus(status, post, transaction, chatRoom, seller, buyer);
+  }
+
+  private Pair<Member, Member> getRole(Post post, ChatRoom chatRoom) {
+
+    return post.getPostType() == SELL ?
+        Pair.of(post.getAuthor(), chatRoom.getRequestor())
+        : Pair.of(chatRoom.getRequestor(), post.getAuthor());
+  }
+
+  // 현재 상태값과 새로운 상태값을 검증하는 메서드 입니다.
+  private boolean isValidStatus(PostStatus currentStatus, PostStatus newStatus) {
+
+    return switch (currentStatus) {
+      case PENDING -> newStatus == IN_PROGRESS;
+      case IN_PROGRESS -> newStatus == PostStatus.COMPLETED || newStatus == PENDING;
+      case COMPLETED, HIDDEN -> false;
+    };
+  }
+
+  // 게시글의 상태값에 따라 transactionService 를 실행하는 메서드 입니다.
+  private void handleTransactionStatus(PostStatus status, Post post, Transaction transaction,
+      ChatRoom chatRoom, Member seller, Member buyer) {
+
+    switch (status) {
+      case IN_PROGRESS -> {
+
+        // 현재 게시글의 다른 거래가 있는 지 확인합니다.
+        validateTransactionStatus(post);
+
+        if (transaction == null) {
+          transactionService.start(chatRoom, seller, buyer);
+        } else {
+          transactionService.restart(transaction);
+        }
+      }
+
+      case PENDING -> transactionService.cancel(transaction);
+      case COMPLETED -> transactionService.complete(transaction);
+    }
+  }
+
+  private void validateTransactionStatus(Post post) {
+
+    post.getChatRoom().stream()
+        .map(ChatRoom::getTransaction)
+        .filter(Objects::nonNull)
+        .filter(transaction ->
+            transaction.getStatus() == STARTED
+                || transaction.getStatus() == COMPLETED)
+        .findAny()
+        .ifPresent(transaction -> {
+          throw new CustomException(ALREADY_TRANSACTION);
+        });
+  }
+
+  // 주어진 게시글 ID 로 게시글을 찾습니다.
+  public Post findById(Long postId) {
+
+    return postRepository.findById(postId).orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+  }
+
+  // 채팅방 에서 호출할 메서드입니다. 게시글 작성자를 찾습니다.
+  public Member getPostAuthor(Long postId) {
+
+    Post post = findById(postId);
+
+    if (post.getAuthor() == null) {
+      throw new CustomException(MEMBER_NOT_FOUND);
+    } else {
+      return post.getAuthor();
+    }
+  }
+
+  // 특정 게시글의 회원의 찜 여부를 확인하는 메서드 입니다.
+  private boolean isWished(Post post, Long memberId) {
+
+    if (post.getWishes() == null) {
+      return false;
+    }
+    return post.getWishes().stream().anyMatch(wish -> wish.getMember().getId().equals(memberId));
+  }
+
+  // 게시글에서 채팅방의 존재를 확인하는 메서드 입니다.
+  private ChatRoom getChatRoom(Post post, Long chatRoomId) {
+
+    return post.getChatRoom().stream().filter(room -> room.getId().equals(chatRoomId))
+        .findFirst().orElseThrow(() -> new CustomException(CHATROOM_NOT_FOUND));
+  }
+
+  // 게시글 수정 시 게시글 작성자 보인인지 확인하는 메서드 입니다.
+  private void validatePostAuthor(Member member, Post post) {
+
+    if (!member.equals(post.getAuthor())) {
+      throw new CustomException(FORBIDDEN);
+    }
   }
 }

--- a/src/main/java/com/gogym/post/type/PostStatus.java
+++ b/src/main/java/com/gogym/post/type/PostStatus.java
@@ -1,7 +1,16 @@
 package com.gogym.post.type;
 
+import lombok.Getter;
+
+@Getter
 public enum PostStatus {
 
-  // 게시중, 판매완료, 구매완료, 숨김처리 등
-  POSTING, SALE_COMPLETED, PURCHASE_COMPLETED, HIDDEN
+  // 게시중(거래대기), 거래중, 거래완료, 숨김처리 등
+  PENDING("거래대기"), IN_PROGRESS("거래중"), COMPLETED("거래완료"), HIDDEN("숨김처리");
+
+  private final String statusName;
+
+  PostStatus(String statusName) {
+    this.statusName = statusName;
+  }
 }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -10,12 +10,12 @@
         <file>/home/ubuntu/logs/app.log</file>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>logs/app.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>/home/ubuntu/logs/app.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>7</maxHistory>
         </rollingPolicy>
 
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss,Asia/Seoul} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/src/test/java/com/gogym/member/service/MemberServiceTest.java
+++ b/src/test/java/com/gogym/member/service/MemberServiceTest.java
@@ -1,23 +1,23 @@
 package com.gogym.member.service;
 
-import static org.mockito.Mockito.*;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import com.gogym.exception.CustomException;
+import com.gogym.gympay.entity.GymPay;
 import com.gogym.member.dto.MemberProfileResponse;
 import com.gogym.member.dto.UpdateMemberRequest;
 import com.gogym.member.entity.Member;
 import com.gogym.member.repository.BanNicknameRepository;
 import com.gogym.member.repository.MemberRepository;
 import com.gogym.member.type.MemberStatus;
-import com.gogym.gympay.entity.GymPay;
-import org.junit.jupiter.api.Test;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
-import java.util.Optional;
 
 class MemberServiceTest {
 
@@ -42,7 +42,7 @@ class MemberServiceTest {
     Long memberId = 1L;
 
     GymPay gymPay = mock(GymPay.class);
-    when(gymPay.getBalance()).thenReturn(10000L);
+    when(gymPay.getBalance()).thenReturn(10000);
 
     member = mock(Member.class);
     when(member.getId()).thenReturn(1L);
@@ -94,5 +94,3 @@ class MemberServiceTest {
     verify(memberRepository).findById(memberId);
   }
 }
-
-

--- a/src/test/java/com/gogym/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/gogym/notification/service/NotificationServiceTest.java
@@ -57,7 +57,8 @@ class NotificationServiceTest {
   @BeforeEach
   void setUp() {
 
-    member = Member.builder().id(1L).build();
+    member = Member.builder().build();
+    ReflectionTestUtils.setField(member, "id", 1L);
     notificationDto = new NotificationDto(1L, ADD_WISHLIST_MY_POST, "test message", null);
     notification = Notification.of(member, notificationDto);
     readNotification = new Notification(member, ADD_WISHLIST_MY_POST, "test message", true);

--- a/src/test/java/com/gogym/post/service/PostServiceTest.java
+++ b/src/test/java/com/gogym/post/service/PostServiceTest.java
@@ -3,19 +3,27 @@ package com.gogym.post.service;
 import static com.gogym.exception.ErrorCode.DELETED_POST;
 import static com.gogym.exception.ErrorCode.FORBIDDEN;
 import static com.gogym.exception.ErrorCode.POST_NOT_FOUND;
+import static com.gogym.exception.ErrorCode.REQUEST_VALIDATION_FAIL;
 import static com.gogym.post.type.MembershipType.MEMBERSHIP_ONLY;
+import static com.gogym.post.type.PostStatus.COMPLETED;
 import static com.gogym.post.type.PostStatus.HIDDEN;
-import static com.gogym.post.type.PostStatus.POSTING;
+import static com.gogym.post.type.PostStatus.IN_PROGRESS;
+import static com.gogym.post.type.PostStatus.PENDING;
 import static com.gogym.post.type.PostType.SELL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.gogym.chat.entity.ChatRoom;
+import com.gogym.chat.repository.ChatRoomRepository;
+import com.gogym.chat.service.ChatRoomService;
 import com.gogym.exception.CustomException;
+import com.gogym.gympay.service.TransactionService;
 import com.gogym.member.entity.Member;
 import com.gogym.member.repository.MemberRepository;
 import com.gogym.member.service.MemberService;
@@ -27,6 +35,7 @@ import com.gogym.post.entity.Gym;
 import com.gogym.post.entity.Post;
 import com.gogym.post.repository.GymRepository;
 import com.gogym.post.repository.PostRepository;
+import com.gogym.post.type.PostStatus;
 import com.gogym.region.dto.RegionResponseDto;
 import com.gogym.region.entity.Region;
 import com.gogym.region.service.RegionService;
@@ -45,6 +54,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class PostServiceTest {
@@ -73,6 +83,15 @@ class PostServiceTest {
   @Mock
   private RecentViewService recentViewService;
 
+  @Mock
+  private ChatRoomService chatRoomService;
+
+  @Mock
+  private ChatRoomRepository chatRoomRepository;
+
+  @Mock
+  private TransactionService transactionService;
+
   @InjectMocks
   private PostService postService;
 
@@ -87,15 +106,20 @@ class PostServiceTest {
   private Page<Post> posts;
   private PostUpdateRequestDto postUpdateRequestDto;
   private PostUpdateRequestDto postDeleteRequestDto;
+  private ChatRoom chatRoom;
+  private Member seller;
+  private Member buyer;
+  private PostStatus status;
 
   @BeforeEach
   void setUp() {
 
     member = Member.builder()
-        .id(1L)
         .regionId1(1L)
         .regionId2(2L)
         .build();
+    ReflectionTestUtils.setField(member, "id", 1L);
+
     parent = Region.builder()
         .id(1L)
         .name("도시")
@@ -126,7 +150,7 @@ class PostServiceTest {
 
     regionIds = List.of(1L, 2L);
 
-    postUpdateRequestDto = new PostUpdateRequestDto("수정 제목", "내용", SELL, POSTING, MEMBERSHIP_ONLY,
+    postUpdateRequestDto = new PostUpdateRequestDto("수정 제목", "내용", SELL, PENDING, MEMBERSHIP_ONLY,
         LocalDate.now().plusMonths(1), null, 1000L, null, null, null);
 
     postDeleteRequestDto = new PostUpdateRequestDto("제목", "내용", SELL, HIDDEN, MEMBERSHIP_ONLY,
@@ -150,7 +174,7 @@ class PostServiceTest {
     // given
     posts = new PageImpl<>(List.of(post), pageable, 1);
 
-    when(postRepository.findAllByStatusOrderByCreatedAtDesc(pageable, POSTING)).thenReturn(posts);
+    when(postRepository.findAllByStatusOrderByCreatedAtDesc(pageable, PENDING)).thenReturn(posts);
     // when
     Page<PostPageResponseDto> result = postService.getAllPosts(null, pageable);
     // then
@@ -165,7 +189,7 @@ class PostServiceTest {
     posts = new PageImpl<>(List.of(post), pageable, 1);
 
     when(memberService.findById(member.getId())).thenReturn(member);
-    when(postRepository.findAllByStatusAndRegionIds(POSTING, pageable, regionIds)).thenReturn(
+    when(postRepository.findAllByStatusAndRegionIds(PENDING, pageable, regionIds)).thenReturn(
         posts);
     // when
     Page<PostPageResponseDto> result = postService.getAllPosts(member.getId(), pageable);
@@ -180,10 +204,10 @@ class PostServiceTest {
     // given
     posts = new PageImpl<>(List.of(post), pageable, 1);
     member = Member.builder()
-        .id(1L)
         .regionId1(null)
         .regionId2(null)
         .build();
+    ReflectionTestUtils.setField(member, "id", 1L);
 
     when(memberService.findById(member.getId())).thenReturn(member);
     // when
@@ -235,12 +259,13 @@ class PostServiceTest {
   @Test
   void 게시글_작성자가_아니면_예외가_발생한다() {
     // given
-    Member anotherMember = Member.builder().id(2L).build();
+    Member anotherMember = Member.builder().regionId1(10L).regionId2(11L).build();
+    ReflectionTestUtils.setField(anotherMember, "id", 2L);
     when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
-    when(memberService.findById(member.getId())).thenReturn(anotherMember);
+    doReturn(anotherMember).when(memberService).findById(anotherMember.getId());
     // when
     CustomException e = assertThrows(CustomException.class,
-        () -> postService.updatePost(member.getId(), post.getId(), postUpdateRequestDto));
+        () -> postService.updatePost(anotherMember.getId(), post.getId(), postUpdateRequestDto));
     // then
     assertEquals(e.getErrorCode(), FORBIDDEN);
     assertEquals(e.getMessage(), "권한이 없습니다.");
@@ -260,5 +285,77 @@ class PostServiceTest {
     assertEquals(post.getStatus(), HIDDEN);
     assertEquals(e.getErrorCode(), DELETED_POST);
     assertEquals(e.getMessage(), "삭제된 게시글입니다.");
+  }
+
+  @Test
+  void 게시글의_상태를_성공적으로_변경한다() {
+    // given
+    seller = Member.builder().build();
+    ReflectionTestUtils.setField(seller, "id", 1L);
+
+    buyer = Member.builder().build();
+    ReflectionTestUtils.setField(buyer, "id", 2L);
+
+    chatRoom = ChatRoom.builder().post(post).requestor(buyer).build();
+    ReflectionTestUtils.setField(chatRoom, "id", 1L);
+
+    post = Post.builder().author(seller).status(PENDING).chatRoom(List.of(chatRoom)).build();
+    status = IN_PROGRESS;
+
+    when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
+    when(memberService.findById(seller.getId())).thenReturn(seller);
+    // when
+    postService.changePostStatus(seller.getId(), post.getId(), chatRoom.getId(), status);
+    // then
+    assertEquals(post.getStatus(), IN_PROGRESS);
+  }
+
+  @Test
+  void 게시글의_상태변경이_유효하지_않으면_예외가_발생한다() {
+    // given
+    seller = Member.builder().build();
+    ReflectionTestUtils.setField(seller, "id", 1L);
+
+    buyer = Member.builder().build();
+    ReflectionTestUtils.setField(buyer, "id", 2L);
+
+    chatRoom = ChatRoom.builder().post(post).requestor(buyer).build();
+    ReflectionTestUtils.setField(chatRoom, "id", 1L);
+
+    post = Post.builder().author(seller).status(COMPLETED).chatRoom(List.of(chatRoom)).build();
+    status = IN_PROGRESS;
+
+    when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
+    when(memberService.findById(seller.getId())).thenReturn(seller);
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> postService.changePostStatus(seller.getId(), post.getId(), chatRoom.getId(), status));
+    // then
+    assertEquals(e.getErrorCode(), REQUEST_VALIDATION_FAIL);
+    assertEquals(e.getMessage(), "'거래완료' 상태는 '거래중' 상태로 변경할 수 없습니다.");
+  }
+
+  @Test
+  void 게시글의_상태가_HIDDEN_이면_다른상태로_변경할_수_없다() {
+    // given
+    seller = Member.builder().build();
+    ReflectionTestUtils.setField(seller, "id", 1L);
+
+    buyer = Member.builder().build();
+    ReflectionTestUtils.setField(buyer, "id", 2L);
+    chatRoom = ChatRoom.builder().post(post).requestor(buyer).build();
+
+    ReflectionTestUtils.setField(chatRoom, "id", 1L);
+    post = Post.builder().author(seller).status(HIDDEN).chatRoom(List.of(chatRoom)).build();
+    status = IN_PROGRESS;
+
+    when(memberService.findById(seller.getId())).thenReturn(seller);
+    when(postRepository.findById(post.getId())).thenReturn(Optional.of(post));
+    // when
+    CustomException e = assertThrows(CustomException.class,
+        () -> postService.changePostStatus(seller.getId(), post.getId(), chatRoom.getId(), status));
+    // then
+    assertEquals(e.getErrorCode(), REQUEST_VALIDATION_FAIL);
+    assertEquals(e.getMessage(), "'숨김처리' 상태는 '거래중' 상태로 변경할 수 없습니다.");
   }
 }

--- a/src/test/java/com/gogym/post/service/RecentViewServiceTest.java
+++ b/src/test/java/com/gogym/post/service/RecentViewServiceTest.java
@@ -43,7 +43,7 @@ class RecentViewServiceTest {
   void setUp() {
 
     pageable = PageRequest.of(0, 10);
-    member = Member.builder().id(1L).build();
+    member = Member.builder().build();
     gym = Gym.builder().gymName("헬스장").build();
     post = Post.builder().author(member).gym(gym).build();
   }

--- a/src/test/java/com/gogym/post/service/WishServiceTest.java
+++ b/src/test/java/com/gogym/post/service/WishServiceTest.java
@@ -60,7 +60,7 @@ class WishServiceTest {
   @BeforeEach
   void setUp() {
 
-    member = Member.builder().id(1L).build();
+    member = Member.builder().build();
     gym = Gym.builder().gymName("헬스장").build();
     post = Post.builder().author(member).gym(gym).wishCount(1L).build();
     post2 = Post.builder().author(member).gym(gym).wishCount(1L).build();


### PR DESCRIPTION
## ⚡️ Issue 번호
<!-- 작업한 내용에 해당하는 Issue 번호를 꼭! 기록해주세요 !
키워드: close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved
예시: close #10 !-->
#79 

## 🛠️ 작업 내용 (What)
- 보안관련 설정 수정
- 로깅 시간대를 한국 시간대로 변경
- 로그인 반환값으로 ID 필드 추가
- notification 구독시 필요 파라미터 변경
- 게시글 status 변경 API

## 📌 작업 이유 (Why)
- 게시글의 상태가 변경되면 거래가 진행 또는 취소, 완료 가 됩니다.

## ✨ 변경 사항 (Changes)
- 보안
  - SecurityConfig 에 엔드포인트를 추가하였습니다.
  - WebConfig 에 CORS 추가 설정 하였습니다.
  - JWT 필터링 중 인증, 인가 가 필요없는 엔드포인트 경로를 정확하게 찾기 위해 AntPathMatcher 를 사용하였습니다.

- 알림
  - notification sse 서버에서 테스트 하기 위해 헤더에 토큰 대신 ID 값을 받는것으로 수정하였습니다.
  - 추가적으로 로그인 시 ID 필드를 추가로 반환하였습니다.

- 로깅
  - aws 서버에 날자별로 logging 이 되지않던 문제가 있어 경로를 수정하였습니다.
  - aws 서버에서 log 확인할때, utc 시간대로 되어있어 한국 시간으로 변경하였습니다.

- 게시글 공통
  - 게시글과 찜, 게시글과 채팅방 등 양방향 설정을 하여 접근이 용이하도록 하였습니다.
  - 게시글 상태 변경 추가됨으로써, 게시글 수정 시 게시글 상태가 PENDING 또는 HIDDEN 만 허용하는것으로 로직을 강화하였습니다.

- 게시글 찜
  - 게시글 반환 시 본인의 찜목록이 되어있는 게시글 인지 판단하는 필드 추가하였습니다.
  - 해당 필드는 게시글 조회 시 하트 모양이 꽉찬 하트, 빈 하트 등으로 프론트에서 구현하기 위한 필드입니다.

- 게시글 상태 변경
  - 게시글의 타입(SELL, BUY) 에 따라 회원의 SELLER 또는 BUYER 역할 지정하였습니다.
  - 게시글 작성자가 아니면 게시글 상태를 변경할 수 없습니다.
  - 게시글이 변환될 수 있는 상태를 강제하여, 이를 어길 시 예외발생합니다.
  - 예외발생 시 상태를 명확히 알기위해 enum 에 상태명을 설정하였습니다.
    - 거래대기 상태에서 구매중 으로 변경 가능
    - 구매중 상태에서 거래완료 또는 거래대기 로 변경 가능
    - 거래완료 또는 숨김 된 게시글은 변경 불가능
  - 변경된 게시글의 다른 거래가 잡힌게 있다면 예외발생합니다.(중복거래 방지)
  - 변경된 게시글의 상태가 거래중 이고, 연결된 Transaction 이 없다면 새로운 거래시작 메서드를 호출 합니다.
  - 변경된 게시글의 상태가 거래중 이고, 연결된 Transaction(이전 거래) 가 있다면 기존 정보로 거래 재시작 메서드를 호출 합니다.
  - 변경된 게시글의 상태가 거래대기 이면, 거래 취소 메서드를 호출 합니다.
  - 변경된 게시글의 상태가 거래완료 이면, 거래 완료 메서드를 호출 합니다.
  - 게시글 타입 기존 POSTING 에서 PENDING 으로 변경 하였습니다.

## ✅ 테스트 (Tests)
- [ ] 게시글의 상태를 성공적으로 변경한다
- [ ] 게시글의 상태변경이 유효하지 않으면 예외가 발생한다
- [ ] 게시글의 상태가 HIDDEN 이면 다른상태로 변경할 수 없다

## 💬 리뷰 포인트 (Review Points)
보안 관련 설정 중 잘못된 부분이 있다면 바로 알려주시면 다시 커밋하겠습니다!

승현님과 하얀님의 로직이 각각 겹치는 부분이 있을 수 있어, conflict 발생방지로 먼저 Merge 하시면 다시 커밋 하겠습니다.