### PR TITLE
♻️ refactor : 채팅방 목록 및 메시지 조회 Response 개선 및 순환 의존성 문제 해결

### DIFF
--- a/src/main/java/com/gogym/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/gogym/chat/controller/ChatMessageController.java
@@ -19,21 +19,21 @@ public class ChatMessageController {
   private final ChatMessageQueryService chatMessageQueryService;
   
   /**
-   * 특정 채팅방의 메시지와 해당 채팅방에 연결된 게시물 상태를 조회합니다.
+   * 특정 채팅방의 메시지와 해당 채팅방에 연결된 게시물 정보를 조회합니다.
    * 
    * GET /api/chatroom/{chatroom-id}/messages?page={page}&size={size}
    * 
    * @param memberId 요청 사용자 ID
    * @param chatRoomId 조회할 채팅방 ID
    * @param pageable 페이지네이션 정보 (page, size)
-   * @return {@link ChatRoomMessagesResponse} 메시지 목록과 게시물 상태
+   * @return {@link ChatRoomMessagesResponse} 메시지 목록과 연결된 게시물 정보
    */
   @GetMapping("/{chatroom-id}/messages")
   public ResponseEntity<ChatRoomMessagesResponse> getMessagesInChatroom(
       @LoginMemberId Long memberId,
       @PathVariable("chatroom-id") Long chatRoomId,
       Pageable pageable) {
-    return ResponseEntity.ok(this.chatMessageQueryService.getMessagesWithPostStatus(memberId, chatRoomId, pageable));
+    return ResponseEntity.ok(this.chatMessageQueryService.getChatRoomMessagesAndPostInfo(memberId, chatRoomId, pageable));
   }
   
 }

--- a/src/main/java/com/gogym/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/gogym/chat/dto/ChatMessageDto.java
@@ -3,7 +3,7 @@ package com.gogym.chat.dto;
 import java.time.LocalDateTime;
 import org.springframework.data.domain.Page;
 import com.gogym.chat.type.MessageType;
-import com.gogym.post.type.PostStatus;
+import com.gogym.post.dto.PostResponseDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -33,7 +33,7 @@ public class ChatMessageDto {
 
   public record ChatRoomMessagesResponse(
       Page<ChatMessageResponse> messages,
-      PostStatus postStatus,
+      PostResponseDto post,
       LocalDateTime leaveAt) {}
 
 }

--- a/src/main/java/com/gogym/chat/dto/ChatRoomDto.java
+++ b/src/main/java/com/gogym/chat/dto/ChatRoomDto.java
@@ -11,6 +11,7 @@ public class ChatRoomDto {
       Long postId,
       Long counterpartyId,
       String counterpartyNickname,
+      String counterpartyProfileImageUrl,
       int unreadMessageCount,
       String lastMessage,
       LocalDateTime lastMessageAt,

--- a/src/main/java/com/gogym/chat/entity/ChatRoom.java
+++ b/src/main/java/com/gogym/chat/entity/ChatRoom.java
@@ -1,23 +1,20 @@
 package com.gogym.chat.entity;
 
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
 import com.gogym.common.entity.BaseEntity;
 import com.gogym.exception.CustomException;
 import com.gogym.exception.ErrorCode;
-import com.gogym.gympay.entity.Transaction;
 import com.gogym.member.entity.Member;
 import com.gogym.post.entity.Post;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/gogym/chat/service/ChatMessageQueryService.java
+++ b/src/main/java/com/gogym/chat/service/ChatMessageQueryService.java
@@ -11,8 +11,8 @@ public interface ChatMessageQueryService {
    * @param memberId 요청 사용자 ID
    * @param chatRoomId 채팅방 ID
    * @param pageable 페이징 정보
-   * @return {@link ChatRoomMessagesResponse} 채팅 메시지 목록과 게시물 상태
+   * @return {@link ChatRoomMessagesResponse} 채팅 메시지 목록과 채팅방과 연결된 게시물 정보
    */
-  ChatRoomMessagesResponse getMessagesWithPostStatus(Long memberId, Long chatRoomId, Pageable pageable);
+  ChatRoomMessagesResponse getChatRoomMessagesAndPostInfo(Long memberId, Long chatRoomId, Pageable pageable);
   
 }

--- a/src/main/java/com/gogym/chat/service/ChatRoomService.java
+++ b/src/main/java/com/gogym/chat/service/ChatRoomService.java
@@ -1,6 +1,5 @@
 package com.gogym.chat.service;
 
-import com.gogym.chat.entity.ChatRoom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import com.gogym.chat.dto.ChatRoomDto.ChatRoomResponse;

--- a/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/gogym/chat/service/impl/ChatRoomServiceImpl.java
@@ -22,7 +22,6 @@ import com.gogym.member.entity.Member;
 import com.gogym.member.service.MemberService;
 import com.gogym.post.entity.Post;
 import com.gogym.post.service.PostQueryService;
-import com.gogym.post.service.PostService;
 import com.gogym.post.type.PostStatus;
 import com.gogym.util.JsonUtil;
 import jakarta.transaction.Transactional;
@@ -37,9 +36,8 @@ public class ChatRoomServiceImpl implements ChatRoomQueryService, ChatRoomServic
   private final ChatMessageRepository chatMessageRepository;
   
   private final ChatRedisService chatRedisService;
-  private final MemberService memberService;
-  //private final PostService postService;
   private final PostQueryService postQueryService;
+  private final MemberService memberService;
   
   @Override
   public ChatRoomResponse createChatRoom(Long memberId, Long postId) {
@@ -72,6 +70,7 @@ public class ChatRoomServiceImpl implements ChatRoomQueryService, ChatRoomServic
         postId, // postId
         postAuthor.getId(), // counterpartyId
         postAuthor.getNickname(), // counterpartyNickname
+        postAuthor.getProfileImageUrl(), // counterpartyProfileImageUrl
         0, // unreadMessageCount
         null, // lastMessage
         null,// lastMessageAt
@@ -147,6 +146,7 @@ public class ChatRoomServiceImpl implements ChatRoomQueryService, ChatRoomServic
           chatRoom.getPost().getId(), // postId
           counterparty.getId(), // counterpartyId
           counterparty.getNickname(), // counterpartyNickname
+          counterparty.getProfileImageUrl(), // counterpartyProfileImageUrl
           unreadMessageCount, // unreadMessageCount
           lastMessage != null ? lastMessage.getContent() : null, // lastMessage
           lastMessageAt, // lastMessageAt

--- a/src/main/java/com/gogym/post/service/PostQueryService.java
+++ b/src/main/java/com/gogym/post/service/PostQueryService.java
@@ -6,4 +6,5 @@ import com.gogym.post.entity.Post;
 public interface PostQueryService {
   Member getPostAuthor(Long postId);
   Post findById(Long postId);
+  boolean isWished(Post post, Long memberId);
 }

--- a/src/main/java/com/gogym/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/com/gogym/post/service/PostQueryServiceImpl.java
@@ -32,4 +32,11 @@ public class PostQueryServiceImpl implements PostQueryService {
     return postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
   }
   
+  @Override
+  public  boolean isWished(Post post, Long memberId) {
+    return post.getWishes() != null
+        ? post.getWishes().stream().anyMatch(wish -> wish.getMember().getId().equals(memberId))
+        : false;
+  }
+  
 }

--- a/src/main/java/com/gogym/post/service/PostService.java
+++ b/src/main/java/com/gogym/post/service/PostService.java
@@ -4,14 +4,20 @@ import static com.gogym.exception.ErrorCode.ALREADY_TRANSACTION;
 import static com.gogym.exception.ErrorCode.CHATROOM_NOT_FOUND;
 import static com.gogym.exception.ErrorCode.DELETED_POST;
 import static com.gogym.exception.ErrorCode.FORBIDDEN;
-import static com.gogym.exception.ErrorCode.MEMBER_NOT_FOUND;
 import static com.gogym.exception.ErrorCode.POST_NOT_FOUND;
 import static com.gogym.exception.ErrorCode.REQUEST_VALIDATION_FAIL;
 import static com.gogym.post.type.PostStatus.HIDDEN;
 import static com.gogym.post.type.PostStatus.IN_PROGRESS;
 import static com.gogym.post.type.PostStatus.PENDING;
 import static com.gogym.post.type.PostType.SELL;
-
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.util.Pair;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import com.gogym.chat.entity.ChatRoom;
 import com.gogym.exception.CustomException;
 import com.gogym.gympay.entity.Transaction;
@@ -30,15 +36,7 @@ import com.gogym.post.repository.PostRepositoryCustom;
 import com.gogym.post.type.PostStatus;
 import com.gogym.region.dto.RegionResponseDto;
 import com.gogym.region.service.RegionService;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.util.Pair;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -59,7 +57,6 @@ public class PostService {
 
   private final TransactionService transactionService;
   
-  //
   private final PostQueryService postQueryService;
 
   @Transactional
@@ -131,7 +128,7 @@ public class PostService {
       recentViewService.saveRecentView(member, post);
     }
 
-    boolean isWished = isWished(post, memberId);
+    boolean isWished = postQueryService.isWished(post, memberId);
 
     RegionResponseDto regionResponseDto = regionService.findById(post.getGym().getRegionId());
 
@@ -145,10 +142,9 @@ public class PostService {
 
     Member member = memberService.findById(memberId);
 
-    //Post post = findById(postId);
     Post post = postQueryService.findById(postId);
 
-    boolean isWished = isWished(post, memberId);
+    boolean isWished = postQueryService.isWished(post, memberId);
 
     validatePostAuthor(member, post);
 
@@ -279,33 +275,6 @@ public class PostService {
     if (validateTransactionStatus) {
       throw new CustomException(ALREADY_TRANSACTION);
     }
-  }
-/*
-  // 주어진 게시글 ID 로 게시글을 찾습니다.
-  public Post findById(Long postId) {
-
-    return postRepository.findById(postId).orElseThrow(() -> new CustomException(POST_NOT_FOUND));
-  }
-
-  // 채팅방 에서 호출할 메서드입니다. 게시글 작성자를 찾습니다.
-  public Member getPostAuthor(Long postId) {
-
-    Post post = findById(postId);
-
-    if (post.getAuthor() == null) {
-      throw new CustomException(MEMBER_NOT_FOUND);
-    } else {
-      return post.getAuthor();
-    }
-  }
-*/
-  // 특정 게시글의 회원의 찜 여부를 확인하는 메서드 입니다.
-  private boolean isWished(Post post, Long memberId) {
-
-    if (post.getWishes() == null) {
-      return false;
-    }
-    return post.getWishes().stream().anyMatch(wish -> wish.getMember().getId().equals(memberId));
   }
 
   // 게시글에서 채팅방의 존재를 확인하는 메서드 입니다.

--- a/src/test/java/com/gogym/chat/service/impl/ChatMessageBatchSchedulerTest.java
+++ b/src/test/java/com/gogym/chat/service/impl/ChatMessageBatchSchedulerTest.java
@@ -27,13 +27,13 @@ import com.gogym.chat.repository.ChatRoomRepository;
 import com.gogym.chat.schedule.ChatMessageBatchScheduler;
 import com.gogym.chat.type.MessageType;
 import com.gogym.exception.CustomException;
-import com.gogym.util.RedisUtil;
+import com.gogym.util.RedisService;
 
 @ExtendWith(MockitoExtension.class)
 class ChatMessageBatchSchedulerTest {
 
   @Mock
-  private RedisUtil redisUtil;
+  private RedisService redisService;
 
   @Mock
   private RedisTemplate<String, Object> redisTemplate;
@@ -62,8 +62,8 @@ class ChatMessageBatchSchedulerTest {
     // RedisTemplate Mock 설정
     when(this.redisTemplate.keys("chatroom:messages:*")).thenReturn(Set.of(redisKey));
 
-    // RedisUtil Mock 설정
-    when(this.redisUtil.lrange(redisKey, 0, -1)).thenReturn(List.of(mockMessageJson));
+    // RedisService Mock 설정
+    when(this.redisService.lrange(redisKey, 0, -1)).thenReturn(List.of(mockMessageJson));
 
     // ChatRoomRepository Mock 설정
     when(this.chatRoomRepository.findById(chatroomId)).thenReturn(Optional.of(mockChatRoom));
@@ -81,7 +81,7 @@ class ChatMessageBatchSchedulerTest {
     assertEquals(mockChatRoom, savedMessage.getChatRoom());
     assertEquals(MessageType.TEXT_ONLY, savedMessage.getMessageType());
 
-    verify(this.redisUtil, times(1)).delete(redisKey);
+    verify(this.redisService, times(1)).delete(redisKey);
   }
 
   @Test
@@ -94,8 +94,8 @@ class ChatMessageBatchSchedulerTest {
     // RedisTemplate Mock 설정
     when(this.redisTemplate.keys("chatroom:messages:*")).thenReturn(Set.of(redisKey));
 
-    // RedisUtil Mock 설정
-    when(this.redisUtil.lrange(redisKey, 0, -1)).thenReturn(List.of(validMessageJson));
+    // RedisService Mock 설정
+    when(this.redisService.lrange(redisKey, 0, -1)).thenReturn(List.of(validMessageJson));
 
     // ChatRoomRepository Mock 설정
     when(this.chatRoomRepository.findById(chatroomId)).thenReturn(Optional.empty());
@@ -112,8 +112,8 @@ class ChatMessageBatchSchedulerTest {
     // RedisTemplate Mock 설정
     when(this.redisTemplate.keys("chatroom:messages:*")).thenReturn(Set.of(redisKey));
 
-    // RedisUtil Mock 설정 (Redis에 메시지가 없는 상황)
-    when(this.redisUtil.lrange(redisKey, 0, -1)).thenReturn(List.of()); // 빈 리스트 반환
+    // RedisService Mock 설정 (Redis에 메시지가 없는 상황)
+    when(this.redisService.lrange(redisKey, 0, -1)).thenReturn(List.of()); // 빈 리스트 반환
 
     // When
     assertDoesNotThrow(() -> this.chatMessageBatchScheduler.batchMessagesToDatabase());
@@ -121,7 +121,7 @@ class ChatMessageBatchSchedulerTest {
     // Then
     verify(this.chatRoomRepository, times(0)).findById(anyLong());
     verify(this.chatMessageRepository, times(0)).save(any(ChatMessage.class));
-    verify(this.redisUtil, times(0)).delete(redisKey);
+    verify(this.redisService, times(0)).delete(redisKey);
   }
 
 }

--- a/src/test/java/com/gogym/chat/service/impl/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/gogym/chat/service/impl/ChatRoomServiceImplTest.java
@@ -37,7 +37,6 @@ import com.gogym.member.entity.Member;
 import com.gogym.member.service.MemberService;
 import com.gogym.post.entity.Post;
 import com.gogym.post.service.PostQueryService;
-import com.gogym.post.service.PostService;
 import com.gogym.post.type.PostStatus;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,12 +50,10 @@ class ChatRoomServiceImplTest {
 
   @Mock
   private MemberService memberService;
-/*
-  @Mock
-  private PostService postService;
-*/
+  
   @Mock
   private PostQueryService postQueryService;
+  
   @Mock
   private ChatRedisServiceImpl chatRedisService;
 
@@ -100,9 +97,7 @@ class ChatRoomServiceImplTest {
         .author(this.postAuthor)
         .build();
 
-    //when(this.postService.getPostAuthor(postId)).thenReturn(this.postAuthor);
     when(this.postQueryService.getPostAuthor(postId)).thenReturn(this.postAuthor);
-    //when(this.postService.findById(postId)).thenReturn(mockPost);
     when(this.postQueryService.findById(postId)).thenReturn(mockPost);
 
     // 이미 존재하는 채팅방 여부 확인
@@ -161,7 +156,11 @@ class ChatRoomServiceImplTest {
         any(Pageable.class))).thenReturn(mockPage);
 
     // Redis 메시지 Mock 설정
-    String redisMessageJson = "{\"content\":\"안녕하세요!\",\"senderId\":123,\"createdAt\":\"2024-12-03T12:00:00\"}";
+    String redisMessageJson = 
+        "{\"content\":\"안녕하세요!\","
+        + "\"senderId\":123,"
+        + "\"messageType\":\"TEXT_ONLY\","
+        + "\"createdAt\":\"2024-12-03T12:00:00\"}";
     when(this.chatRedisService.getMessages(chatRoomId)).thenReturn(List.of(redisMessageJson));
 
     // leaveAt 설정
@@ -191,7 +190,11 @@ class ChatRoomServiceImplTest {
     when(this.chatRoomService.isMemberInChatRoom(chatRoomId, memberId)).thenReturn(true);
     
     // Redis 메시지 Mock 설정
-    String redisMessageJson = "{\"content\":\"test message\",\"senderId\":1,\"createdAt\":\"2024-12-10T12:00:00\"}";
+    String redisMessageJson = 
+        "{\"content\":\"안녕하세요!\","
+        + "\"senderId\":123,"
+        + "\"messageType\":\"TEXT_ONLY\","
+        + "\"createdAt\":\"2024-12-03T12:00:00\"}";
     when(this.chatRedisService.getMessages(chatRoomId)).thenReturn(List.of(redisMessageJson));
     
     // When
@@ -240,7 +243,11 @@ class ChatRoomServiceImplTest {
     when(this.chatRoomService.isMemberInChatRoom(chatRoomId, this.postAuthor.getId())).thenReturn(true);
     when(this.chatRoomService.isMemberInChatRoom(chatRoomId, this.requestor.getId())).thenReturn(true);
     
-    String redisMessageJson = "{\"content\":\"test message\",\"senderId\":1,\"createdAt\":\"2024-12-10T12:00:00\"}";
+    String redisMessageJson = 
+        "{\"content\":\"안녕하세요!\","
+        + "\"senderId\":123,"
+        + "\"messageType\":\"TEXT_ONLY\","
+        + "\"createdAt\":\"2024-12-03T12:00:00\"}";
     when(this.chatRoomRepository.findById(chatRoomId)).thenReturn(Optional.of(testChatRoom));
     when(this.chatRedisService.getMessages(chatRoomId))
         .thenReturn(List.of(redisMessageJson)) // 첫 번째 호출에서는 Redis에 메시지 존재

--- a/src/test/java/com/gogym/chat/service/impl/ChatRoomServiceImplTest.java
+++ b/src/test/java/com/gogym/chat/service/impl/ChatRoomServiceImplTest.java
@@ -37,6 +37,7 @@ import com.gogym.member.entity.Member;
 import com.gogym.member.service.MemberService;
 import com.gogym.post.entity.Post;
 import com.gogym.post.service.PostService;
+import com.gogym.post.type.PostStatus;
 
 @ExtendWith(MockitoExtension.class)
 class ChatRoomServiceImplTest {
@@ -91,7 +92,10 @@ class ChatRoomServiceImplTest {
   void 채팅방_생성_성공() {
     // Given
     Long postId = 1L;
-    Post mockPost = null;
+    Post mockPost = Post.builder()
+        .status(PostStatus.PENDING)
+        .author(this.postAuthor)
+        .build();
 
     when(this.postService.getPostAuthor(postId)).thenReturn(this.postAuthor);
     when(this.postService.findById(postId)).thenReturn(mockPost);

--- a/src/test/java/com/gogym/post/service/WishServiceTest.java
+++ b/src/test/java/com/gogym/post/service/WishServiceTest.java
@@ -39,10 +39,7 @@ class WishServiceTest {
 
   @Mock
   private WishRepository wishRepository;
-/*
-  @Mock
-  private PostService postService;
-*/
+  
   @Mock
   private PostQueryService postQueryService;
   @Mock


### PR DESCRIPTION
## ⚡️ Issue 번호
채팅방 목록 및 메시지 조회 Response 개선 #100 
순환 의존성 문제 해결 #101 

## 🛠️ 작업 내용 (What)
- 채팅방 목록 조회 시 상대방 프로필 URL을 Response에 포함하도록 수정.
- 과거 채팅 메시지 이력 조회(채팅방 진입) 시 연관된 게시물 정보를 Response에 포함하도록 수정.
- 순환 의존성 문제를 해결하기 위해 `PostQueryService`를 도입하여 `PostService`의 게시물 조회 기능을 분리.

## 📌 작업 이유 (Why)
- 채팅방 목록과 메시지 이력 조회(채팅방 진입) 시 상대방 프로필 URL 및 연관된 게시물 정보가 클라이언트에 필요함.
- `ChatRoomServiceImpl`과 `PostService` 간 순환 의존성을 제거하여 애플리케이션의 안정성을 향상시키기 위함.

## ✨ 변경 사항 (Changes)
- 채팅 도메인
  - 상대방 프로필 URL을 반환하는 로직 추가.
  - 메시지 이력 조회(채팅방 진입) 시 연관된 게시물 정보를 포함하도록 수정.
- `PostQueryService` 도입
  - 게시물 조회 기능을 `PostQueryService`로 이동하여 분리.
  - `ChatRoomService`가 `PostQueryService`를 참조하도록 수정.
  - 이후 관련 클래스들의 의존성 주입 방식 변경 및 테스트 코드 수정.

## ✅ 테스트 (Tests)
- [x] 채팅방 목록 조회 시 상대방 프로필 URL 반환 테스트
- [x] 메시지 이력 조회(채팅방 진입) 시 연관된 게시물 정보 포함 테스트
- [x] `PostQueryService` 도입 후 의존성 문제 해결 테스트
- [x] `PostQueryService` 도입으로 인한 변경된 테스트 코드 정상 통과 테스트 

## 💬 리뷰 포인트 (Review Points)
- 현재 채팅 도메인의 로직들 중 다른 도메인에 대한 의존성을 최소화할 수 있는 개선 방안이 있다면 말씀 부탁드리겠습니다.
- 추가할 테스트 커버리지가 있다면 말씀 부탁드리겠습니다.
