### PR TITLE
♻️refactor : 알림관련 로직 수정

### DIFF
--- a/src/main/java/com/gogym/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gogym/exception/GlobalExceptionHandler.java
@@ -2,10 +2,12 @@ package com.gogym.exception;
 
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -73,5 +75,20 @@ public class GlobalExceptionHandler {
 
     return ResponseEntity.status(e.getStatusCode()).body(response);
   }
-}
 
+  @ExceptionHandler(AsyncRequestTimeoutException.class)
+  public ResponseEntity<String> handleAsyncRequestTimeoutException(AsyncRequestTimeoutException e) {
+    log.info("SSE Connection Timeout: {}", e.getMessage());
+
+    return ResponseEntity.noContent().build();
+  }
+  @ExceptionHandler(RuntimeException.class)
+  public ResponseEntity<String> handleRuntimeException(RuntimeException e) {
+    log.error("SSE RuntimeException: {}", e.getMessage());
+
+    String sseErrorResponse = "event: error\ndata: Unexpected error occurred\n\n";
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .contentType(MediaType.TEXT_EVENT_STREAM)
+        .body(sseErrorResponse);
+  }
+}

--- a/src/main/java/com/gogym/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/gogym/exception/GlobalExceptionHandler.java
@@ -1,16 +1,15 @@
 package com.gogym.exception;
 
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
-import jakarta.servlet.http.HttpServletRequest;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
@@ -81,14 +80,5 @@ public class GlobalExceptionHandler {
     log.info("SSE Connection Timeout: {}", e.getMessage());
 
     return ResponseEntity.noContent().build();
-  }
-  @ExceptionHandler(RuntimeException.class)
-  public ResponseEntity<String> handleRuntimeException(RuntimeException e) {
-    log.error("SSE RuntimeException: {}", e.getMessage());
-
-    String sseErrorResponse = "event: error\ndata: Unexpected error occurred\n\n";
-    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-        .contentType(MediaType.TEXT_EVENT_STREAM)
-        .body(sseErrorResponse);
   }
 }

--- a/src/main/java/com/gogym/notification/service/NotificationService.java
+++ b/src/main/java/com/gogym/notification/service/NotificationService.java
@@ -80,7 +80,8 @@ public class NotificationService {
         try {
           emitter.send(SseEmitter.event()
               .name("dummy")
-              .data("connecting..."));
+              .data("connecting...")
+              .reconnectTime(3000L));
           log.info("✅ 더미 이벤트 발송 완료!: {}", memberId);
         } catch (IOException e) {
           log.error("🚨 더미 이벤트 발송 중 예외 발생!: {}", e.getMessage());
@@ -113,7 +114,8 @@ public class NotificationService {
         NotificationDto notificationDto = NotificationDto.fromEntity(notification);
         emitter.send(SseEmitter.event()
             .name("notification")
-            .data(notificationDto));
+            .data(notificationDto)
+            .reconnectTime(3000L));
         log.info("✅ 알림 이벤트 발송 완료!: {}", memberId);
       } catch (IOException e) {
         log.error("🚨 알림 이벤트 발송 중 예외 발생!: {}", e.getMessage());

--- a/src/main/java/com/gogym/notification/service/NotificationService.java
+++ b/src/main/java/com/gogym/notification/service/NotificationService.java
@@ -49,9 +49,18 @@ public class NotificationService {
     emitters.put(memberId, emitter);
 
     // 클라이언트 연결 종료, 만료, 에러 처리
-    emitter.onCompletion(() -> removeEmitter(memberId));
-    emitter.onTimeout(() -> removeEmitter(memberId));
-    emitter.onError((e) -> removeEmitter(memberId));
+    emitter.onCompletion(() -> {
+      log.info("👍SSE 구독 정상 해제 (memberId : {}),", memberId);
+      removeEmitter(memberId);
+    });
+    emitter.onTimeout(() -> {
+      log.warn("🕰️SSE 구독 타임 아웃 (memberId : {}),", memberId);
+      removeEmitter(memberId);
+    });
+    emitter.onError((e) -> {
+      log.error("🚨SSE 구독 알수없는 에러 발생 \n📍memberId: {}, \n📍에러: {}", memberId, e.getMessage());
+      removeEmitter(memberId);
+    });
 
     sendDummyData(memberId, emitter);
 
@@ -72,6 +81,7 @@ public class NotificationService {
           emitter.send(SseEmitter.event()
               .name("dummy")
               .data("connecting..."));
+          log.info("✅ 더미 이벤트 발송 완료!: {}", memberId);
         } catch (IOException e) {
           log.error("🚨 더미 이벤트 발송 중 예외 발생!: {}", e.getMessage());
           removeEmitter(memberId);
@@ -104,6 +114,7 @@ public class NotificationService {
         emitter.send(SseEmitter.event()
             .name("notification")
             .data(notificationDto));
+        log.info("✅ 알림 이벤트 발송 완료!: {}", memberId);
       } catch (IOException e) {
         log.error("🚨 알림 이벤트 발송 중 예외 발생!: {}", e.getMessage());
         removeEmitter(memberId);


### PR DESCRIPTION
## ⚡️ Issue 번호
<!-- 작업한 내용에 해당하는 Issue 번호를 꼭! 기록해주세요 !
키워드: close, closes, closed- fix, fixes, fixed- resolve, resolves, resolved
예시: close #10 !-->
#103 

## 🛠️ 작업 내용 (What)
- sse 구독 요청을 하면 2초 뒤에 첫 event 가 발송되도록 thread 를 지연 시켰습니다.
- sse 구독이 Timeout 이 될 경우 적절한 예외처리와 명확한 로그가 남도록 처리하였습니다.

## 📌 작업 이유 (Why)
- 현재 sse 구독 요청이 되면 이벤트 발송이 되지 않는 문제가 있습니다.
- sse 구독이 Timeout 이 될 경우 (프론트의 재 연결 로직이 정상 작동 하지 않아 재구독 요청을 하지 않는 경우) 에러 로그가 남는 문제가 발생하였습니다.

## ✨ 변경 사항 (Changes)
- thread 를 sleep 으로 지연시키면 다수의 사용자가 sse 구독 요청을 보낼 경우, 병목현상이 발생할 가능성이 있다고 생각되어, ScheduledExecutorService 를 사용하여 구독 후 첫 이벤트를 비동기로 지연 발송하도록 변경하였습니다.
- 이벤트 발송 후 이벤트가 잘 발송이 되었는지 로그를 추가적으로 남겼습니다.
- 클라이언트의 재구독 요청이 없을 때, sse Timeout 이 발생하면 명확히 알기 위해 에러 로그를 강화하였습니다.
