### PR TITLE
✨ feat: 채팅방 목록 조회 쿼리 개선 및 초기 메시지 브로드캐스팅 기능 추가

### DIFF
--- a/src/main/java/com/gogym/chat/dto/base/RedisMessage.java
+++ b/src/main/java/com/gogym/chat/dto/base/RedisMessage.java
@@ -14,7 +14,8 @@ import com.gogym.chat.type.MessageType;
 )
 @JsonSubTypes({
     @JsonSubTypes.Type(value = SafePaymentRedisMessage.class, name = "SafePaymentRedisMessage"),
-    @JsonSubTypes.Type(value = RedisChatMessage.class, name = "RedisChatMessage")})
+    @JsonSubTypes.Type(value = RedisChatMessage.class, name = "RedisChatMessage")}
+)
 public interface RedisMessage {
   String content();
   Long senderId();

--- a/src/main/java/com/gogym/chat/event/ChatRoomEvent.java
+++ b/src/main/java/com/gogym/chat/event/ChatRoomEvent.java
@@ -1,0 +1,20 @@
+package com.gogym.chat.event;
+
+import org.springframework.context.ApplicationEvent;
+import lombok.Getter;
+
+@Getter
+public class ChatRoomEvent extends ApplicationEvent {
+  
+  private final Long chatRoomId;
+  private final Long requestorId;
+  private final String requestorNickname;
+  
+  public ChatRoomEvent(Object source, Long chatRoomId, Long requestorId, String requestorNickname) {
+    super(source);
+    this.chatRoomId = chatRoomId;
+    this.requestorId = requestorId;
+    this.requestorNickname = requestorNickname;
+  }
+  
+}

--- a/src/main/java/com/gogym/chat/event/listener/ChatRoomEventListener.java
+++ b/src/main/java/com/gogym/chat/event/listener/ChatRoomEventListener.java
@@ -1,0 +1,28 @@
+package com.gogym.chat.event.listener;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import com.gogym.chat.dto.ChatMessageDto.ChatMessageRequest;
+import com.gogym.chat.event.ChatRoomEvent;
+import com.gogym.chat.service.ChatMessageService;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ChatRoomEventListener {
+  
+  private final ChatMessageService chatMessageService;
+  
+  @EventListener
+  public void handleChatRoomCreated(ChatRoomEvent event) {
+    // 초기 메시지 전송
+    this.chatMessageService.sendMessage(
+        new ChatMessageRequest(
+            event.getChatRoomId(),
+            String.format("%s님이 채팅을 요청하였습니다.", event.getRequestorNickname())
+        ),
+        event.getRequestorId()
+    );
+  }
+  
+}

--- a/src/main/java/com/gogym/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/gogym/chat/repository/ChatRoomRepository.java
@@ -42,7 +42,10 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
       LEFT JOIN cr.post p
       LEFT JOIN p.author a
       LEFT JOIN ChatMessage cm ON cm.chatRoom.id = cr.id
-      WHERE (a.id = :postAuthorId OR cr.requestor.id = :requestorId)
+      WHERE 
+        (a.id = :postAuthorId AND cr.postAuthorActive = true) 
+        OR 
+        (cr.requestor.id = :requestorId AND cr.requestorActive = true)
         AND cr.isDeleted = false
       GROUP BY cr.id, p.id, a.id, cr.requestor.id, cr.isDeleted
       ORDER BY MAX(cm.createdAt) DESC


### PR DESCRIPTION
## ⚡️ Issue 번호
채팅방 목록 조회 쿼리 개선 #120 
채팅방 생성 시 초기 메시지 브로드캐스팅을 위한 Event 발행 #122 

## 🛠️ 작업 내용 (What)
- 채팅방 목록 조회 쿼리 개선
  - `findChatRoomsSortedByLastMessage` 쿼리에 사용자 역할별 활성 상태(`postAuthorActive`, `requestorActive`) 조건 추가.
  - 게시글 작성자 또는 요청자의 활성 상태가 true인 경우에만 조회.
- 채팅방 생성 시 초기 메시지 브로드캐스팅
  - 채팅방 생성 직후 이벤트 기반으로 초기 메시지 전송.
  - 요청자가 "{닉네임}님이 채팅을 요청하였습니다." 메시지를 전송한 것처럼 Redis와 DB에 저장 및 브로드캐스팅.

## 📌 작업 이유 (Why)
- 채팅방 목록에 사용자가 삭제하거나 비활성화한 채팅방이 노출되지 않도록 하기 위함.
- 요청자가 채팅방을 생성했음을 명시적으로 알리기 위함.

## ✨ 변경 사항 (Changes)
- 쿼리 변경
  - `findChatRoomsSortedByLastMessage`
- 초기 메시지 전송
  - `ChatRoomEvent` 추가
  - `ChatRoomEventListener`를 통해 메시지 브로드캐스팅

## ✅ 테스트 (Tests)
- [x] 채팅방 목록 조회 쿼리에서 비활성화된 채팅방이 제외되는지 확인.
- [x] 테스트 코드 이상 없음 확인.

## 💬 리뷰 포인트 (Review Points)
- `findChatRoomsSortedByLastMessage` 쿼리에 추가된 조건이 정확한지와 성능에 문제는 없을지 확인 부탁드립니다.
- 이벤트 기반 로직이 적절한지 확인 부탁드립니다.

## 🔍 추가 사항 (Additions)
- 채팅방 생성 시 메시지 브로드캐스팅되는 부분은 프론트엔드와의 통합 테스트가 필요합니다.
