### PR TITLE
♻️ refactor: 카카오 기능 리팩토링

### DIFF
--- a/src/main/java/com/gogym/config/SecurityConfig.java
+++ b/src/main/java/com/gogym/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                 "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
                 "/api/auth/send-verification-email", "/api/regions", "/api/kakao/sign-in/**",
                 "/api/posts/views", "/api/posts/filters", "/api/posts/details/**",
-                "/api/payments/webhook",
+                "/api/payments/webhook","/api/auth/sign-up/kakao",
                 "/api/payments/sse/subscribe/**", "/api/images/presigned-url", "/ws/**",
                 "/api/notifications/subscribe/**")
             .permitAll()
@@ -69,7 +69,7 @@ public class SecurityConfig {
 
   // 인증 제외 경로
   private List<String> exemptUrls() {
-    return List.of("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
+    return List.of("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email","/api/auth/sign-up/kakao",
         "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
         "/api/auth/send-verification-email", "/api/regions", "/api/kakao/sign-in/**",
         "/api/posts/views", "/api/posts/filters", "/api/posts/details/**", "/api/payments/webhook",

--- a/src/main/java/com/gogym/member/controller/AuthController.java
+++ b/src/main/java/com/gogym/member/controller/AuthController.java
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-public class AuthController { 
+public class AuthController {
 
   private final AuthService authService;
   private final EmailService emailService;
@@ -38,6 +38,14 @@ public class AuthController {
   public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
     authService.signUp(request);
     return ResponseEntity.status(HttpStatus.OK).build();
+  }
+
+  // 카카오로 회원가입
+  @PostMapping("/sign-up/kakao")
+  public ResponseEntity<Void> kakaoSignUp(@RequestBody @Valid SignUpRequest request) {
+    authService.signUp(request);
+    authService.completeKakaoSignUp(request.getEmail());
+    return ResponseEntity.ok().build();
   }
 
   // 로그인
@@ -52,7 +60,7 @@ public class AuthController {
     Member member = authService.getMemberByEmail(request.getEmail());
     LoginResponse loginResponse = new LoginResponse(member.getId(), member.getEmail(),
         member.getName(), member.getNickname(), member.getPhone());
- 
+
     // HttpHeaders를 사용하여 헤더에 Authorization 추가
     HttpHeaders headers = new HttpHeaders();
     headers.add("Authorization", "Bearer " + accessToken);
@@ -61,6 +69,7 @@ public class AuthController {
     // ResponseEntity에 헤더와 바디를 추가
     return ResponseEntity.ok().headers(headers).body(loginResponse);
   }
+
 
   // 로그아웃
   @PostMapping("/sign-out")

--- a/src/main/java/com/gogym/member/controller/KakaoController.java
+++ b/src/main/java/com/gogym/member/controller/KakaoController.java
@@ -23,7 +23,7 @@ public class KakaoController {
   private final KakaoService kakaoService;
 
   @GetMapping("/sign-in")
-  public ResponseEntity<KakaoLoginResponse> handleKakaoLogin(@RequestParam("code") String code) {
+  public ResponseEntity<Map<String, Object>> handleKakaoLogin(@RequestParam("code") String code) {
     KakaoLoginResponse response = kakaoService.processKakaoLogin(code);
 
     HttpHeaders headers = new HttpHeaders();
@@ -31,6 +31,11 @@ public class KakaoController {
       headers.add("Authorization", "Bearer " + response.getToken());
     }
 
-    return ResponseEntity.ok().headers(headers).body(response);
+    Map<String, Object> responseBody = new HashMap<>();
+    responseBody.put("email", response.getEmail());
+    responseBody.put("existingUser", response.isExistingUser());
+
+    return ResponseEntity.ok().headers(headers).body(responseBody);
   }
+
 }

--- a/src/main/java/com/gogym/member/controller/KakaoController.java
+++ b/src/main/java/com/gogym/member/controller/KakaoController.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import com.gogym.member.dto.KakaoLoginResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,19 +24,18 @@ public class KakaoController {
   private final KakaoService kakaoService;
 
   @GetMapping("/sign-in")
-  public ResponseEntity<Map<String, Object>> handleKakaoLogin(@RequestParam("code") String code) {
+  public ResponseEntity<KakaoLoginResponse> handleKakaoLogin(@RequestParam("code") String code) {
     KakaoLoginResponse response = kakaoService.processKakaoLogin(code);
 
     HttpHeaders headers = new HttpHeaders();
-    if (response.getToken() != null) {
-      headers.add("Authorization", "Bearer " + response.getToken());
+    String token = kakaoService.generateJwtToken(response.getEmail());
+    if (token != null) {
+      headers.add("Authorization", "Bearer " + token);
     }
 
-    Map<String, Object> responseBody = new HashMap<>();
-    responseBody.put("email", response.getEmail());
-    responseBody.put("existingUser", response.isExistingUser());
-
-    return ResponseEntity.ok().headers(headers).body(responseBody);
+    // 응답 본문은 email과 existingUser 정보만 반환
+    return ResponseEntity.ok().headers(headers).body(response);
   }
+
 
 }

--- a/src/main/java/com/gogym/member/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/gogym/member/dto/KakaoLoginResponse.java
@@ -8,5 +8,6 @@ import lombok.Getter;
 public class KakaoLoginResponse {
   private final boolean isExistingUser;
   private final String token;
+  private String email;
 }
 

--- a/src/main/java/com/gogym/member/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/gogym/member/dto/KakaoLoginResponse.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public class KakaoLoginResponse {
   private final boolean isExistingUser;
-  private final String token;
-  private String email;
+  private final String email;
 }
 

--- a/src/main/java/com/gogym/member/service/AuthService.java
+++ b/src/main/java/com/gogym/member/service/AuthService.java
@@ -23,7 +23,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class AuthService { 
+public class AuthService {
 
   private final MemberService memberService;
 
@@ -178,14 +178,12 @@ public class AuthService {
     }
   }
 
-  // 카카오 회원가입 업데이트 로직
   @Transactional
   public void completeKakaoSignUp(String email) {
     Member member = memberRepository.findByEmail(email)
         .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
-    // isKakao 값을 true로 업데이트
-    member.setKakao(true);
+    member.setKakao(true); // isKakao 값을 true로 설정
   }
 
 }

--- a/src/main/java/com/gogym/member/service/KakaoService.java
+++ b/src/main/java/com/gogym/member/service/KakaoService.java
@@ -36,8 +36,7 @@ public class KakaoService {
 
   // Redirect URI 생성 메서드
   private String generateRedirectUri() {
-    // return "https://gogym-eight.vercel.app/kakaoLogin";
-    return "http://localhost:8080/api/kakao/sign-in";
+    return "https://gogym-eight.vercel.app/kakaoLogin";
   }
 
   public KakaoLoginResponse processKakaoLogin(String code) {
@@ -48,18 +47,18 @@ public class KakaoService {
     // 2. 이메일로 회원 정보 조회
     String email = profileResponse.kakaoAccount().email();
     log.info("카카오 사용자 이메일: {}", email);
-    
+
     Member member = memberService.findByEmail(email);
     // 카카오 사용자가 아니라면 로그인 불가
     if (!member.isKakao()) {
       log.warn("회원이 카카오 사용자가 아님 - 이메일: {}", email);
-      return new KakaoLoginResponse(false, null, email);
+      return new KakaoLoginResponse(false, email);
     }
 
     // JWT 토큰 발행
     String token = jwtTokenProvider.createToken(member.getEmail(), member.getId(),
         List.of(member.getRole().name()));
-    return new KakaoLoginResponse(true, token, email);
+    return new KakaoLoginResponse(true, email);
   }
 
   // 카카오 인증 URL 생성 메서드
@@ -106,5 +105,12 @@ public class KakaoService {
     log.info("카카오 사용자 정보 응답: {}", response.getBody());
     return response.getBody();
   }
+
+  public String generateJwtToken(String email) {
+    Member member = memberService.findByEmail(email);
+    return jwtTokenProvider.createToken(member.getEmail(), member.getId(),
+        List.of(member.getRole().name()));
+  }
+
 
 }


### PR DESCRIPTION
## ⚡️ Issue 번호

카카오 로그인 로직 구현 [#67](https://github.com/ProjectGoGym/BackEnd/issues/67)

## 🛠️ 작업 내용 (What)

- 카카오 로그인 로직 구현 완료
- 기존 회원 여부(existingUser) 확인 및 JWT 토큰 발급
- 신규 회원일 경우 이메일 반환 및 회원가입 로직으로 연결
- JWT 토큰은 HTTP 헤더로 반환하도록 수정

## 📌 작업 이유 (Why)

- 카카오 소셜 로그인을 통한 사용자 인증 및 회원가입 기능 제공
- 기존 회원과 신규 회원을 구분하여 적절히 처리하기 위함
- 보안 강화를 위해 JWT 토큰을 Response Body 대신 HTTP 헤더로 전달

## ✨ 변경 사항 (Changes)

카카오 로그인 로직 (/api/kakao/sign-in)

- 기존 회원 여부(isKakao 값)를 확인하여 응답 반환
- JWT 토큰은 Authorization 헤더로 전달
- 신규 회원일 경우 이메일과 existingUser : false 반환

회원가입 로직 추가 (/sign-up/kakao)
- 회원가입 완료 시 isKakao 값을 자동으로 true로 설정

## ✅ 테스트 (Tests)
- [x] 로컬 환경에서 카카오 로그인되고, response 값 반환 하는 것 확인
- [x] 로컬 환경에서 DB에 isKakao 변환되는 것 것 확인
- [ ] 프론트앤드 테스트

## 💬 리뷰 포인트 (Review Points)

수정된 로직 

![제목 없음](https://github.com/user-attachments/assets/26f3bf63-5a2c-4331-ae48-74afd951b0af)

 카카오 로그인 후 값 반환 된 것 확인 (토큰값 헤더로 옮기는 부분 수정했습니다)

![1](https://github.com/user-attachments/assets/b80324a9-1a28-46e7-98d7-5dd1770b4762)

