### PR TITLE
♻️ SecurityConfig 리팩토링

### DIFF
--- a/src/main/java/com/gogym/config/SecurityConfig.java
+++ b/src/main/java/com/gogym/config/SecurityConfig.java
@@ -41,21 +41,20 @@ public class SecurityConfig {
   // SecurityFilterChain Bean 등록
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-    http.csrf().disable().cors(Customizer.withDefaults())
-    .authorizeHttpRequests(auth -> auth
-            // 인증 없이 접근을 허용할 엔드포인트
-            .requestMatchers("/api/auth/sign-up", "/api/auth/sign-in", "/api/auth/check-email",
-                "/api/auth/check-nickname", "/api/auth/verify-email", "/api/auth/reset-password",
-                "/api/auth/send-verification-email", "/api/regions", "/api/kakao/sign-in",
-                "/api/posts/views", "/api/posts/filters", "/api/posts/details/**",
-                "/api/payments/webhook",
-                "/api/payments/sse/subscribe/**", "/api/images/presigned-url", "/ws/**",
-                "/api/notifications/subscribe/**")
-            .permitAll()
-            .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-            // 그 외의 모든 요청은 인증 필요
-            .anyRequest().authenticated())
-        // JWT 인증 필터를 AuthenticationFilter 전에 추가
+    http.csrf(csrf -> csrf.disable()).cors(Customizer.withDefaults())
+        .authorizeHttpRequests(
+            auth -> auth
+                .requestMatchers(HttpMethod.POST, "/api/auth/sign-up", "/api/auth/sign-in",
+                    "/api/auth/send-verification-email", "/api/payments/webhook", "/ws/**")
+                .permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/auth/check-email",
+                    "/api/auth/check-nickname", "/api/auth/verify-email", "/api/regions",
+                    "/api/kakao/sign-in/**", "/api/posts/views", "/api/posts/filters",
+                    "/api/posts/details/**", "/api/payments/**", "/api/images/presigned-url",
+                    "/api/notifications/subscribe/**")
+                .permitAll().requestMatchers(HttpMethod.PUT, "/api/auth/reset-password").permitAll()
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll().anyRequest()
+                .authenticated())
         .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
     return http.build();

--- a/src/main/java/com/gogym/config/SecurityConfig.java
+++ b/src/main/java/com/gogym/config/SecurityConfig.java
@@ -41,20 +41,24 @@ public class SecurityConfig {
   // SecurityFilterChain Bean 등록
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-    http.csrf(csrf -> csrf.disable()).cors(Customizer.withDefaults())
-        .authorizeHttpRequests(
-            auth -> auth
-                .requestMatchers(HttpMethod.POST, "/api/auth/sign-up", "/api/auth/sign-in",
-                    "/api/auth/send-verification-email", "/api/payments/webhook", "/ws/**")
-                .permitAll()
-                .requestMatchers(HttpMethod.GET, "/api/auth/check-email",
-                    "/api/auth/check-nickname", "/api/auth/verify-email", "/api/regions",
-                    "/api/kakao/sign-in/**", "/api/posts/views", "/api/posts/filters",
-                    "/api/posts/details/**", "/api/payments/**", "/api/images/presigned-url",
-                    "/api/notifications/subscribe/**")
-                .permitAll().requestMatchers(HttpMethod.PUT, "/api/auth/reset-password").permitAll()
-                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll().anyRequest()
-                .authenticated())
+    http.csrf().disable().cors(Customizer.withDefaults()).authorizeHttpRequests(auth -> auth
+        // 인증 없이 접근을 허용할 엔드포인트
+        .requestMatchers(HttpMethod.POST, "/api/auth/sign-up", "/api/auth/sign-in",
+            "/api/auth/send-verification-email", "/api/payments/webhook", "/ws/**")
+        .permitAll()
+
+        .requestMatchers(HttpMethod.GET, "/api/auth/check-email", "/api/auth/check-nickname",
+            "/api/auth/verify-email", "/api/regions", "/api/kakao/sign-in/**", "/api/posts/views",
+            "/api/posts/filters", "/api/posts/details/**", "/api/payments/**",
+            "/api/images/presigned-url", "/api/notifications/subscribe/**")
+        .permitAll()
+
+        .requestMatchers(HttpMethod.PUT, "/api/auth/reset-password").permitAll()
+
+        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+        // 그 외의 모든 요청은 인증 필요
+        .anyRequest().authenticated())
+        // JWT 인증 필터를 AuthenticationFilter 전에 추가
         .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
     return http.build();

--- a/src/main/java/com/gogym/config/SecurityConfig.java
+++ b/src/main/java/com/gogym/config/SecurityConfig.java
@@ -41,24 +41,20 @@ public class SecurityConfig {
   // SecurityFilterChain Bean 등록
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-    http.csrf().disable().cors(Customizer.withDefaults()).authorizeHttpRequests(auth -> auth
-        // 인증 없이 접근을 허용할 엔드포인트
-        .requestMatchers(HttpMethod.POST, "/api/auth/sign-up", "/api/auth/sign-in",
-            "/api/auth/send-verification-email", "/api/payments/webhook", "/ws/**")
-        .permitAll()
-
-        .requestMatchers(HttpMethod.GET, "/api/auth/check-email", "/api/auth/check-nickname",
-            "/api/auth/verify-email", "/api/regions", "/api/kakao/sign-in/**", "/api/posts/views",
-            "/api/posts/filters", "/api/posts/details/**", "/api/payments/**",
-            "/api/images/presigned-url", "/api/notifications/subscribe/**")
-        .permitAll()
-
-        .requestMatchers(HttpMethod.PUT, "/api/auth/reset-password").permitAll()
-
-        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-        // 그 외의 모든 요청은 인증 필요
-        .anyRequest().authenticated())
-        // JWT 인증 필터를 AuthenticationFilter 전에 추가
+    http.csrf(csrf -> csrf.disable()).cors(Customizer.withDefaults())
+        .authorizeHttpRequests(
+            auth -> auth
+                .requestMatchers(HttpMethod.POST, "/api/auth/sign-up", "/api/auth/sign-in",
+                    "/api/auth/send-verification-email", "/api/payments/webhook", "/ws/**")
+                .permitAll()
+                .requestMatchers(HttpMethod.GET, "/api/auth/check-email",
+                    "/api/auth/check-nickname", "/api/auth/verify-email", "/api/regions",
+                    "/api/kakao/sign-in/**", "/api/posts/views", "/api/posts/filters",
+                    "/api/posts/details/**", "/api/payments/**", "/api/images/presigned-url",
+                    "/api/notifications/subscribe/**")
+                .permitAll().requestMatchers(HttpMethod.PUT, "/api/auth/reset-password").permitAll()
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll().anyRequest()
+                .authenticated())
         .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
     return http.build();


### PR DESCRIPTION
## 🛠️ 작업 내용 (What)
- `HttpSecurity` 구성에서 기존 방식 대신 Lambda DSL 문법을 적용하여 리팩토링
- 코드 가독성 및 최신 Spring Security 권장사항 준수를 위해 변경

## 📌 작업 이유 (Why)
- 기존 `HttpSecurity` 설정 방식은 중첩된 체이닝 구조로 인해 가독성이 떨어짐
- Spring Security의 최신 권장 방식에 맞추어 코드를 개선하고 유지보수성을 향상

## ✨ 변경 사항 (Changes)
- `csrf().disable()` → `csrf(csrf -> csrf.disable())`와 같이 Lambda DSL 적용
- `.authorizeHttpRequests`에서 각 요청에 대한 권한 설정을 Lambda DSL로 변경

## ✅ 테스트 (Tests)
- [ ] 

## 💬 리뷰 포인트 (Review Points)
- Lambda DSL로 전환된 구문의 가독성이 적절한지 확인부탁드립니다
- 새로운 방식으로 변경하면서 기존 동작에 영향이 없는지 확인 부탁드립니다
